### PR TITLE
change variables in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ raw_vars <- get_raw_variables("cycle1", variables, variable_details)
 df_mock <- data.frame(id = 1:1000)
 
 # Generate a categorical variable
-result <- create_cat_var("DHH_SEX", "cycle1", variable_details, variables,
+result <- create_cat_var("alc_11", "cycle1", variable_details, variables,
                         length = 1000, df_mock = df_mock, seed = 123)
 if (!is.null(result)) {
   df_mock <- cbind(df_mock, result)
 }
 
 # Generate a continuous variable
-result <- create_con_var("HWTGBMI", "cycle1", variable_details, variables,
+result <- create_con_var("alcdwky", "cycle1", variable_details, variables,
                         length = 1000, df_mock = df_mock, seed = 123)
 if (!is.null(result)) {
   df_mock <- cbind(df_mock, result)


### PR DESCRIPTION
Small suggestion: neither sex nor BMI are included in the details sheet for the CHMS data set. As a result, when we call `create_car_var()` and `create_con_var()`, `result` is `NULL`. I suggest replacing these variables with categorical and continuous variables that are actually present in the details sheet (e.g., `alc_11`, `alcdwky`).