### PR TITLE
Fix v0.3 critical metadata regressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,13 @@ vars_with_garbage <- variables %>%
 - Fixed categorical garbage factor level bug - garbage values were being converted to NA during factor creation
 - Fixed `recEnd` column requirement - now optional for simple configurations
 - Fixed derived variable generation in `create_mock_data()` - derived variables now correctly excluded
+- Fixed `create_mock_data()` error handling: strict mode is now the default, so unsupported `rType` values and generator errors stop generation instead of silently dropping columns. Use `validate = FALSE` to opt into warning-and-skip behavior.
+- Fixed role matching so `disabled` no longer matches `enabled`.
+- Fixed missing-code classification to use `recEnd` metadata instead of numeric-code heuristics, so valid codes such as 7, 17, and 27 are not misclassified as missing.
+- Fixed `variable_details = NULL` fallback mode for categorical, continuous, and date variables.
+- Fixed `rType` normalization so `date`/`Date` handling is consistent across validation, defaults, and generation.
+- Added migration warnings for legacy `corrupt_*` garbage fields and recStart values, rewriting them to canonical `garbage_*` names.
+- Added validation that `garbage_low_prop + garbage_high_prop` does not exceed 1, preventing silent truncation of the second garbage pass.
 
 ## Documentation
 

--- a/R/config_helpers.R
+++ b/R/config_helpers.R
@@ -1,3 +1,5 @@
+#' Match Role Tokens
+#' @noRd
 .role_matches <- function(role_values, roles, ignore.case = TRUE) {
   if (length(role_values) == 0) {
     return(logical(0))
@@ -12,7 +14,7 @@
       return(FALSE)
     }
 
-    tokens <- trimws(unlist(strsplit(as.character(value), "[,;]")))
+    tokens <- trimws(unlist(strsplit(as.character(value), "[,;[:space:]]+")))
     tokens <- tokens[tokens != ""]
 
     if (ignore.case) {
@@ -23,6 +25,8 @@
   }, logical(1))
 }
 
+#' Migrate Legacy Garbage Column Aliases
+#' @noRd
 .migrate_garbage_aliases <- function(variables) {
   alias_map <- c(
     corrupt_low_prop = "garbage_low_prop",
@@ -83,9 +87,9 @@
 #' @return Data frame with subset of config rows matching any of the specified roles.
 #'
 #' @details
-#' This function handles comma- or semicolon-separated role values by exact token
-#' matching. A variable matches if any role token equals one of the requested
-#' roles.
+#' This function handles comma-, semicolon-, or whitespace-separated role values
+#' by exact token matching. A variable matches if any role token equals one of
+#' the requested roles.
 #'
 #' Common role values:
 #' - enabled: Variables to generate in mock data

--- a/R/config_helpers.R
+++ b/R/config_helpers.R
@@ -1,3 +1,75 @@
+.role_matches <- function(role_values, roles, ignore.case = TRUE) {
+  if (length(role_values) == 0) {
+    return(logical(0))
+  }
+
+  if (ignore.case) {
+    roles <- tolower(roles)
+  }
+
+  vapply(role_values, function(value) {
+    if (is.na(value) || trimws(value) == "") {
+      return(FALSE)
+    }
+
+    tokens <- trimws(unlist(strsplit(as.character(value), "[,;]")))
+    tokens <- tokens[tokens != ""]
+
+    if (ignore.case) {
+      tokens <- tolower(tokens)
+    }
+
+    any(tokens %in% roles)
+  }, logical(1))
+}
+
+.migrate_garbage_aliases <- function(variables) {
+  alias_map <- c(
+    corrupt_low_prop = "garbage_low_prop",
+    corrupt_low_range = "garbage_low_range",
+    corrupt_high_prop = "garbage_high_prop",
+    corrupt_high_range = "garbage_high_range"
+  )
+
+  aliases_present <- intersect(names(alias_map), names(variables))
+  if (length(aliases_present) == 0) {
+    return(variables)
+  }
+
+  for (alias in aliases_present) {
+    canonical <- unname(alias_map[[alias]])
+
+    if (!canonical %in% names(variables)) {
+      variables[[canonical]] <- variables[[alias]]
+    } else {
+      alias_has_value <- !is.na(variables[[alias]]) & variables[[alias]] != ""
+      canonical_missing <- is.na(variables[[canonical]]) | variables[[canonical]] == ""
+
+      fill_idx <- alias_has_value & canonical_missing
+      variables[[canonical]][fill_idx] <- variables[[alias]][fill_idx]
+
+      conflict_idx <- alias_has_value & !canonical_missing &
+        variables[[alias]] != variables[[canonical]]
+      if (any(conflict_idx, na.rm = TRUE)) {
+        warning(
+          "'", alias, "' and '", canonical,
+          "' both have values for some rows. Keeping '", canonical, "'.",
+          call. = FALSE
+        )
+      }
+    }
+  }
+
+  warning(
+    "The corrupt_* garbage columns are deprecated. ",
+    "Use garbage_low_prop, garbage_low_range, garbage_high_prop, and ",
+    "garbage_high_range instead.",
+    call. = FALSE
+  )
+
+  variables
+}
+
 #' Get variables by role
 #'
 #' @description
@@ -11,8 +83,9 @@
 #' @return Data frame with subset of config rows matching any of the specified roles.
 #'
 #' @details
-#' This function handles comma-separated role values by using grepl() pattern matching.
-#' A variable matches if its role column contains any of the specified role values.
+#' This function handles comma- or semicolon-separated role values by exact token
+#' matching. A variable matches if any role token equals one of the requested
+#' roles.
 #'
 #' Common role values:
 #' - enabled: Variables to generate in mock data
@@ -56,12 +129,8 @@ get_variables_by_role <- function(config, roles) {
     stop("roles must be a non-empty character vector")
   }
 
-  # Build pattern to match any of the specified roles
-  # Use word boundaries to avoid partial matches (e.g., "table1" shouldn't match "table1_master")
-  pattern <- paste0("\\b(", paste(roles, collapse = "|"), ")\\b")
-
-  # Filter using grepl (handles comma-separated role values)
-  matches <- grepl(pattern, config$role, ignore.case = FALSE)
+  # Filter using exact role tokens so "disabled" does not match "enabled".
+  matches <- .role_matches(config$role, roles, ignore.case = TRUE)
 
   result <- config[matches, ]
 

--- a/R/create_cat_var.R
+++ b/R/create_cat_var.R
@@ -157,7 +157,9 @@ create_cat_var <- function(var,
 
   # Filter variable_details for this var AND database (using databaseStart)
   # databaseStart is a recodeflow core column containing comma-separated database identifiers
-  if ("databaseStart" %in% names(variable_details)) {
+  if (is.null(variable_details)) {
+    details_subset <- data.frame(variable = character(0), stringsAsFactors = FALSE)
+  } else if ("databaseStart" %in% names(variable_details)) {
     details_subset <- variable_details[
       variable_details$variable == var &
       (is.na(variable_details$databaseStart) |
@@ -193,6 +195,18 @@ create_cat_var <- function(var,
     ))
     # Generate simple 2-category variable with uniform distribution
     values <- sample(c("1", "2"), size = n, replace = TRUE)
+    if ("rType" %in% names(var_row)) {
+      r_type <- var_row$rType
+      if (!is.null(r_type) && !is.na(r_type) && r_type != "") {
+        values <- switch(r_type,
+          "factor" = factor(values, levels = c("1", "2")),
+          "character" = as.character(values),
+          "integer" = as.integer(values),
+          "logical" = as.logical(as.integer(values) - 1L),
+          values
+        )
+      }
+    }
 
     col <- data.frame(
       new = values,

--- a/R/create_cat_var.R
+++ b/R/create_cat_var.R
@@ -195,6 +195,7 @@ create_cat_var <- function(var,
     ))
     # Generate simple 2-category variable with uniform distribution
     values <- sample(c("1", "2"), size = n, replace = TRUE)
+    # Fallback still honors rType so output contracts match configured metadata.
     if ("rType" %in% names(var_row)) {
       r_type <- var_row$rType
       if (!is.null(r_type) && !is.na(r_type) && r_type != "") {

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -154,7 +154,9 @@ create_con_var <- function(var,
 
   # Filter variable_details for this var AND database (using databaseStart)
   # databaseStart is a recodeflow core column containing comma-separated database identifiers
-  if ("databaseStart" %in% names(variable_details)) {
+  if (is.null(variable_details)) {
+    details_subset <- data.frame(variable = character(0), stringsAsFactors = FALSE)
+  } else if ("databaseStart" %in% names(variable_details)) {
     details_subset <- variable_details[
       variable_details$variable == var &
       (is.na(variable_details$databaseStart) |
@@ -189,6 +191,17 @@ create_con_var <- function(var,
       "'. Using fallback uniform range [0, 100]."
     ))
     values <- runif(n, min = 0, max = 100)
+    if ("rType" %in% names(var_row)) {
+      r_type <- var_row$rType
+      if (!is.null(r_type) && !is.na(r_type) && r_type != "") {
+        values <- switch(r_type,
+          "integer" = as.integer(round(values)),
+          "double" = as.double(values),
+          "numeric" = as.numeric(values),
+          values
+        )
+      }
+    }
 
     col <- data.frame(
       new = values,

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -191,6 +191,7 @@ create_con_var <- function(var,
       "'. Using fallback uniform range [0, 100]."
     ))
     values <- runif(n, min = 0, max = 100)
+    # Fallback still honors rType so output contracts match configured metadata.
     if ("rType" %in% names(var_row)) {
       r_type <- var_row$rType
       if (!is.null(r_type) && !is.na(r_type) && r_type != "") {

--- a/R/create_date_var.R
+++ b/R/create_date_var.R
@@ -156,7 +156,9 @@ create_date_var <- function(var,
 
   # Filter variable_details for this var AND database (using databaseStart)
   # databaseStart is a recodeflow core column containing comma-separated database identifiers
-  if ("databaseStart" %in% names(variable_details)) {
+  if (is.null(variable_details)) {
+    details_subset <- data.frame(variable = character(0), stringsAsFactors = FALSE)
+  } else if ("databaseStart" %in% names(variable_details)) {
     details_subset <- variable_details[
       variable_details$variable == var &
       (is.na(variable_details$databaseStart) |

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -26,7 +26,7 @@
 #'     \item \code{catLabel}: Category label/description
 #'   }
 #'   Can also be a file path (character) to variable_details.csv.
-#'   If NULL, uses fallback mode (uniform distributions).
+#'   If NULL, uses simple fallback generation.
 #' @param n Integer. Number of observations to generate (default 1000).
 #' @param seed Integer. Optional random seed for reproducibility.
 #' @param validate Logical. Whether to use strict generation checks (default
@@ -53,8 +53,9 @@
 #'   \item Return complete dataset
 #' }
 #'
-#' **Fallback mode**: If variable_details = NULL, uses uniform distributions for all
-#' enabled variables.
+#' **Fallback mode**: If variable_details = NULL, uses simple default generators
+#' for enabled variables (two-category categorical values, continuous values from
+#' [0, 100], and dates from 2000-01-01 to 2025-12-31).
 #'
 #' **Variable types supported**:
 #' \itemize{
@@ -135,7 +136,7 @@ create_mock_data <- function(databaseStart,
       variable_details <- read.csv(variable_details, stringsAsFactors = FALSE, check.names = FALSE)
     }
   } else {
-    if (verbose) message("No details file provided - using fallback mode (uniform distributions)")
+    if (verbose) message("No details file provided - using simple fallback generation")
   }
 
   variables <- .migrate_garbage_aliases(variables)
@@ -213,6 +214,7 @@ create_mock_data <- function(databaseStart,
 
   # Initialize empty data frame
   df_mock <- data.frame(row.names = seq_len(n))
+  skipped_vars <- character(0)
 
   # Generate variables in order
   for (i in seq_len(nrow(enabled_vars))) {
@@ -240,15 +242,14 @@ create_mock_data <- function(databaseStart,
     }
 
     supported_rtypes <- c(
-      "factor", "character", "logical", "integer", "double", "numeric", "date",
-      "categorical", "continuous"
+      "factor", "character", "logical", "integer", "double", "numeric", "date"
     )
 
     if (!var_type %in% supported_rtypes) {
       msg <- paste0(
         "Unknown variable type '", var_type, "' for variable: ", var_name,
         "\n  Supported rType values: factor, character, logical, integer, ",
-        "double, numeric, date, categorical, continuous"
+        "double, numeric, date"
       )
 
       if (validate) {
@@ -256,6 +257,7 @@ create_mock_data <- function(databaseStart,
       }
 
       warning(msg)
+      skipped_vars <- c(skipped_vars, var_name)
       var_data <- NULL
     } else {
       # Dispatch to type-specific generator
@@ -324,25 +326,6 @@ create_mock_data <- function(databaseStart,
           df_mock = df_mock,
           n = n,
           seed = NULL
-        ),
-        # Legacy variableType values (if somehow still used)
-        "categorical" = create_cat_var(
-          var = var_name,
-          databaseStart = databaseStart,
-          variables = variables,
-          variable_details = variable_details,
-          df_mock = df_mock,
-          n = n,
-          seed = NULL
-        ),
-        "continuous" = create_con_var(
-          var = var_name,
-          databaseStart = databaseStart,
-          variables = variables,
-          variable_details = variable_details,
-          df_mock = df_mock,
-          n = n,
-          seed = NULL
         )
         )
       }, error = function(e) {
@@ -351,6 +334,7 @@ create_mock_data <- function(databaseStart,
           stop(msg, call. = FALSE)
         }
         warning(msg)
+        skipped_vars <<- c(skipped_vars, var_name)
         NULL
       })
     }
@@ -370,6 +354,12 @@ create_mock_data <- function(databaseStart,
     message("Mock data generation complete!")
     message("  Rows: ", nrow(df_mock))
     message("  Variables: ", ncol(df_mock))
+  }
+
+  if (!validate && length(skipped_vars) > 0) {
+    skipped_vars <- unique(skipped_vars)
+    message("Skipped variables during mock data generation: ",
+            paste(skipped_vars, collapse = ", "))
   }
 
   return(df_mock)

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -29,7 +29,10 @@
 #'   If NULL, uses fallback mode (uniform distributions).
 #' @param n Integer. Number of observations to generate (default 1000).
 #' @param seed Integer. Optional random seed for reproducibility.
-#' @param validate Logical. Whether to validate configuration files (default TRUE).
+#' @param validate Logical. Whether to use strict generation checks (default
+#'   TRUE). When TRUE, unsupported variable types and generator errors stop
+#'   generation. When FALSE, those errors are converted to warnings and the
+#'   affected variable is skipped.
 #' @param verbose Logical. Whether to print progress messages (default FALSE).
 #'
 #' @return Data frame with n rows and one column per enabled variable.
@@ -41,7 +44,7 @@
 #' **Generation process**:
 #' \enumerate{
 #'   \item Load metadata from file paths or accept data frames
-#'   \item Filter for enabled variables (role contains "enabled")
+#'   \item Filter for enabled variables (role has an exact "enabled" token)
 #'   \item Set global seed (if provided)
 #'   \item Loop through variables in position order:
 #'     - Dispatch to create_cat_var, create_con_var, or create_date_var
@@ -135,6 +138,8 @@ create_mock_data <- function(databaseStart,
     if (verbose) message("No details file provided - using fallback mode (uniform distributions)")
   }
 
+  variables <- .migrate_garbage_aliases(variables)
+
   # ========== VALIDATE INPUT ==========
 
   if (n < 1) {
@@ -153,9 +158,9 @@ create_mock_data <- function(databaseStart,
 
   if (verbose) message("Filtering for enabled variables...")
 
-  # Filter for variables with "enabled" in role column
+  # Filter for variables with exact "enabled" role token.
   if ("role" %in% names(variables)) {
-    enabled_vars <- variables[grepl("enabled", variables$role, ignore.case = TRUE), ]
+    enabled_vars <- variables[.role_matches(variables$role, "enabled", ignore.case = TRUE), ]
   } else {
     # If no role column, assume all variables are enabled
     enabled_vars <- variables
@@ -218,8 +223,15 @@ create_mock_data <- function(databaseStart,
     if ("rType" %in% names(var_row) && !is.na(var_row$rType) && var_row$rType != "") {
       var_type <- tolower(var_row$rType)
     } else {
-      stop("Variable '", var_name, "' is missing rType column. ",
-           "All metadata must use v0.2 schema with rType column.")
+      msg <- paste0(
+        "Variable '", var_name, "' is missing rType column. ",
+        "All metadata must use v0.2 schema with rType column."
+      )
+      if (validate) {
+        stop(msg, call. = FALSE)
+      }
+      warning(msg)
+      next
     }
 
     if (verbose) {
@@ -227,9 +239,28 @@ create_mock_data <- function(databaseStart,
               var_name, " (", var_type, ")")
     }
 
-    # Dispatch to type-specific generator
-    var_data <- tryCatch({
-      switch(var_type,
+    supported_rtypes <- c(
+      "factor", "character", "logical", "integer", "double", "numeric", "date",
+      "categorical", "continuous"
+    )
+
+    if (!var_type %in% supported_rtypes) {
+      msg <- paste0(
+        "Unknown variable type '", var_type, "' for variable: ", var_name,
+        "\n  Supported rType values: factor, character, logical, integer, ",
+        "double, numeric, date, categorical, continuous"
+      )
+
+      if (validate) {
+        stop(msg, call. = FALSE)
+      }
+
+      warning(msg)
+      var_data <- NULL
+    } else {
+      # Dispatch to type-specific generator
+      var_data <- tryCatch({
+        switch(var_type,
         # v0.2 schema rType values
         "factor" = create_cat_var(
           var = var_name,
@@ -241,6 +272,15 @@ create_mock_data <- function(databaseStart,
           seed = NULL  # Global seed already set
         ),
         "character" = create_cat_var(
+          var = var_name,
+          databaseStart = databaseStart,
+          variables = variables,
+          variable_details = variable_details,
+          df_mock = df_mock,
+          n = n,
+          seed = NULL
+        ),
+        "logical" = create_cat_var(
           var = var_name,
           databaseStart = databaseStart,
           variables = variables,
@@ -303,17 +343,17 @@ create_mock_data <- function(databaseStart,
           df_mock = df_mock,
           n = n,
           seed = NULL
-        ),
-        {
-          warning("Unknown variable type '", var_type, "' for variable: ", var_name,
-                  "\n  Supported rType values: factor, character, integer, double, numeric, date")
-          NULL
+        )
+        )
+      }, error = function(e) {
+        msg <- paste0("Error generating variable ", var_name, ": ", e$message)
+        if (validate) {
+          stop(msg, call. = FALSE)
         }
-      )
-    }, error = function(e) {
-      warning("Error generating variable ", var_name, ": ", e$message)
-      NULL
-    })
+        warning(msg)
+        NULL
+      })
+    }
 
     # Merge into dataset if generation succeeded
     if (!is.null(var_data) && is.data.frame(var_data)) {

--- a/R/create_wide_survival_data.R
+++ b/R/create_wide_survival_data.R
@@ -33,6 +33,11 @@
 #' @return data.frame with 1-5 date columns (depending on which variables are
 #'   specified), or NULL if variables already exist in df_mock.
 #'
+#' @section Deprecated arguments:
+#' `prop_garbage` is deprecated as of v0.3.0. Configure garbage values on
+#' individual date variables with `garbage_high_prop` and `garbage_high_range`
+#' instead.
+#'
 #' @details
 #' This function implements v0.3.0 "recodeflow pattern" API:
 #' - Accepts full metadata data frames (not pre-filtered subsets)

--- a/R/create_wide_survival_data.R
+++ b/R/create_wide_survival_data.R
@@ -159,6 +159,7 @@
 #' }
 #'
 #' @family generators
+#' @keywords deprecated
 #' @export
 create_wide_survival_data <- function(var_entry_date,
                                        var_event_date = NULL,

--- a/R/create_wide_survival_data.R
+++ b/R/create_wide_survival_data.R
@@ -24,7 +24,7 @@
 #'   already exist and to use as anchor_date source. Default: NULL.
 #' @param n integer. Required. Number of observations to generate.
 #' @param seed integer. Optional. Random seed for reproducibility. Default: NULL.
-#' @param prop_garbage numeric. **DEPRECATED in v0.3.1**. This parameter is no
+#' @param prop_garbage numeric. **DEPRECATED in v0.3.0**. This parameter is no
 #'   longer supported. To generate temporal violations for QA testing, use the
 #'   `garbage_high_prop` and `garbage_high_range` parameters in variables.csv
 #'   for individual date variables. See Details section for migration guidance.
@@ -53,7 +53,7 @@
 #' - If death < event, set event to NA (censored, not missing)
 #' - Observation ends at min(event, death, ltfu, admin_censor)
 #'
-#' **Temporal violations for QA testing (v0.3.1+):**
+#' **Temporal violations for QA testing (v0.3.0+):**
 #' This function creates clean, temporally-ordered survival data. To generate
 #' temporal violations for testing data quality pipelines:
 #' - Add `garbage_high_prop` and `garbage_high_range` to individual date variables
@@ -62,12 +62,12 @@
 #' - Test your temporal validation logic separately
 #' - This approach separates concerns: date-level garbage vs. survival data generation
 #'
-#' **Migration from prop_garbage (deprecated in v0.3.1):**
+#' **Migration from prop_garbage (deprecated in v0.3.0):**
 #' ```r
 #' # OLD (v0.3.0):
 #' surv <- create_wide_survival_data(..., prop_garbage = 0.03)
 #'
-#' # NEW (v0.3.1+):
+#' # NEW (v0.3.0+):
 #' # Add garbage to date variables in metadata
 #' variables$garbage_high_prop[variables$variable == "death_date"] <- 0.03
 #' variables$garbage_high_range[variables$variable == "death_date"] <-
@@ -126,17 +126,18 @@
 #'   var_death_date = NULL,
 #'   var_ltfu = NULL,
 #'   var_admin_censor = NULL,
-#'   database = "study",
+#'   databaseStart = "study",
 #'   variables = variables,
 #'   variable_details = variable_details,
 #'   n = 500,
 #'   seed = 456
 #' )
 #'
-#' # Generate with garbage data for QA testing (v0.3.1+)
+#' # Generate with garbage data for QA testing (v0.3.0+)
 #' # Add garbage to death_date in metadata
 #' vars_with_garbage <- add_garbage(variables, "death_date",
-#'   high_prop = 0.05, high_range = "[2025-01-01, 2099-12-31]")
+#'   garbage_high_prop = 0.05,
+#'   garbage_high_range = "[2025-01-01, 2099-12-31]")
 #'
 #' surv_data <- create_wide_survival_data(
 #'   var_entry_date = "interview_date",
@@ -189,7 +190,7 @@ create_wide_survival_data <- function(var_entry_date,
   # Deprecation warning for prop_garbage
   if (!is.null(prop_garbage)) {
     warning(
-      "The 'prop_garbage' parameter is deprecated as of v0.3.1 and will be ignored.\n",
+      "The 'prop_garbage' parameter is deprecated as of v0.3.0 and will be ignored.\n",
       "To generate temporal violations for QA testing:\n",
       "1. Add garbage_high_prop and garbage_high_range to individual date variables in variables.csv\n",
       "2. Example: variables$garbage_high_prop[variables$variable == 'death_date'] <- 0.03\n",

--- a/R/mockdata_helpers.R
+++ b/R/mockdata_helpers.R
@@ -179,31 +179,15 @@ extract_proportions <- function(details_subset, variable_name = "variable") {
     }
   }
 
-  # Separate missing codes from valid
-  # Common missing code patterns: numeric codes 7,8,9,96,97,98,99,996,997,998,999
-  # Check catLabelLong if it exists, otherwise check recStart pattern
-  #
-  # IMPORTANT: v0.2.1 uses interval notation [min,max] for ranges, which should NOT be treated as missing
-  # Only treat as missing if:
-  #   1. catLabelLong explicitly says "missing", OR
-  #   2. recStart is a single-digit or double-digit code ending in 7,8,9 (not part of a larger range)
-  has_label_long <- "catLabelLong" %in% names(pop_rows)
-
-  # Detect interval notation (ranges for continuous variables): [min,max]
-  is_interval_notation <- grepl("^(\\[|\\().+[,;].+(\\]|\\))$", pop_rows$recStart)
-
-  # Missing codes: explicit label OR numeric codes ending in 7,8,9 (but not interval notation)
-  # Check catLabelLong column if it exists
-  if (has_label_long) {
-    is_missing <- !is_interval_notation & (
-      pop_rows$catLabelLong == "missing" |
-      (grepl("^[0-9]+$", pop_rows$recStart) & grepl("[789]$", pop_rows$recStart))
-    )
+  # Separate missing codes from valid values. recEnd is the authoritative
+  # classification in v0.3 metadata; numeric values such as 7, 17, 27, or 99 can
+  # be legitimate categories in some datasets and must not be inferred missing.
+  if ("recEnd" %in% names(pop_rows)) {
+    is_missing <- grepl("^NA::", pop_rows$recEnd)
+  } else if ("catLabelLong" %in% names(pop_rows)) {
+    is_missing <- tolower(pop_rows$catLabelLong) == "missing"
   } else {
-    # Only check numeric codes ending in 7,8,9
-    is_missing <- !is_interval_notation &
-      grepl("^[0-9]+$", pop_rows$recStart) &
-      grepl("[789]$", pop_rows$recStart)
+    is_missing <- rep(FALSE, nrow(pop_rows))
   }
 
   # Build results
@@ -866,7 +850,7 @@ apply_garbage <- function(values, var_row, variable_type, missing_codes = NULL, 
 #' If rType column is missing, defaults are applied based on variable type:
 #' - `continuous`/`cont` → `"double"`
 #' - `categorical`/`cat` → `"factor"`
-#' - `date` → `"Date"`
+#' - `date` → `"date"`
 #' - `logical` → `"logical"`
 #' - Unknown → `"character"`
 #'
@@ -877,8 +861,7 @@ apply_garbage <- function(values, var_row, variable_type, missing_codes = NULL, 
 #' - `"factor"`: Categorical with levels
 #' - `"character"`: Text codes
 #' - `"logical"`: TRUE/FALSE values
-#' - `"Date"`: Date objects
-#' - `"POSIXct"`: Datetime objects
+#' - `"date"`: Date objects
 #'
 #' @examples
 #' \dontrun{
@@ -908,8 +891,9 @@ apply_rtype_defaults <- function(details) {
   # If rType already exists, validate and return
   if ("rType" %in% names(details)) {
     # Validate rType values
+    details$rType <- tolower(details$rType)
     valid_rtypes <- c("integer", "double", "factor", "character",
-                      "logical", "Date", "POSIXct")
+                      "logical", "date")
     invalid <- setdiff(unique(details$rType[!is.na(details$rType)]), valid_rtypes)
     if (length(invalid) > 0) {
       warning("Invalid rType values found: ", paste(invalid, collapse = ", "),
@@ -938,7 +922,7 @@ apply_rtype_defaults <- function(details) {
     details$rType <- dplyr::case_when(
       type_lower %in% c("cont", "continuous") ~ "double",    # Continuous → double (default)
       type_lower %in% c("cat", "categorical") ~ "factor",    # Categorical → factor (default)
-      type_lower == "date" ~ "Date",                         # Date → Date (default)
+      type_lower == "date" ~ "date",                         # Date -> date (default)
       type_lower == "logical" ~ "logical",                   # Logical → logical
       TRUE ~ "character"                                     # Fallback
     )

--- a/R/mockdata_helpers.R
+++ b/R/mockdata_helpers.R
@@ -858,6 +858,7 @@ apply_garbage <- function(values, var_row, variable_type, missing_codes = NULL, 
 #'
 #' - `"integer"`: Whole numbers (age, counts, years)
 #' - `"double"`: Decimal numbers (BMI, income, percentages)
+#' - `"numeric"`: Numeric vector
 #' - `"factor"`: Categorical with levels
 #' - `"character"`: Text codes
 #' - `"logical"`: TRUE/FALSE values
@@ -892,7 +893,7 @@ apply_rtype_defaults <- function(details) {
   if ("rType" %in% names(details)) {
     # Validate rType values
     details$rType <- tolower(details$rType)
-    valid_rtypes <- c("integer", "double", "factor", "character",
+    valid_rtypes <- c("integer", "double", "numeric", "factor", "character",
                       "logical", "date")
     invalid <- setdiff(unique(details$rType[!is.na(details$rType)]), valid_rtypes)
     if (length(invalid) > 0) {

--- a/R/read_mock_data_config.R
+++ b/R/read_mock_data_config.R
@@ -68,6 +68,7 @@ read_mock_data_config <- function(config_path, validate = TRUE) {
 
   # Read CSV
   config <- read.csv(config_path, stringsAsFactors = FALSE, check.names = FALSE)
+  config <- .migrate_garbage_aliases(config)
 
   # Type conversions
   if ("last_updated" %in% names(config)) {

--- a/R/read_mock_data_config_details.R
+++ b/R/read_mock_data_config_details.R
@@ -68,6 +68,23 @@ read_mock_data_config_details <- function(details_path, validate = TRUE, config 
   # Read CSV
   details <- read.csv(details_path, stringsAsFactors = FALSE, check.names = FALSE)
 
+  if ("recStart" %in% names(details)) {
+    corrupt_rows <- grepl("^corrupt_", details$recStart, ignore.case = TRUE)
+    if (any(corrupt_rows, na.rm = TRUE)) {
+      warning(
+        "The corrupt_* recStart values are deprecated. ",
+        "Use garbage_low, garbage_high, or garbage_future instead.",
+        call. = FALSE
+      )
+      details$recStart[corrupt_rows] <- sub(
+        "^corrupt_",
+        "garbage_",
+        details$recStart[corrupt_rows],
+        ignore.case = TRUE
+      )
+    }
+  }
+
   # Type conversions
   numeric_cols <- c("proportion", "value")
   for (col in numeric_cols) {
@@ -194,9 +211,9 @@ validate_mock_data_config_details <- function(details, config = NULL) {
     for (var in vars) {
       var_rows <- details[details$variable == var, ]
 
-      # Exclude garbage rows. corrupt_* is kept as a legacy alias.
+      # Exclude garbage rows.
       pop_rows <- var_rows[
-        !grepl("^(garbage|corrupt)_", var_rows$recStart, ignore.case = TRUE),
+        !grepl("^garbage_", var_rows$recStart, ignore.case = TRUE),
       ]
 
       # Calculate sum of population proportions (excluding NA)
@@ -215,7 +232,7 @@ validate_mock_data_config_details <- function(details, config = NULL) {
           # Auto-normalize
           norm_factor <- 1.0 / prop_sum
           pop_idx <- which(details$variable == var &
-                          !grepl("^(garbage|corrupt)_", details$recStart, ignore.case = TRUE) &
+                          !grepl("^garbage_", details$recStart, ignore.case = TRUE) &
                           !is.na(details$proportion))
           details$proportion[pop_idx] <- details$proportion[pop_idx] * norm_factor
         }
@@ -241,7 +258,6 @@ validate_mock_data_config_details <- function(details, config = NULL) {
   known_recStart <- c("copy", "distribution", "mean", "sd", "rate", "shape",
                       "valid", "censored",
                       "garbage_low", "garbage_high", "garbage_future",
-                      "corrupt_low", "corrupt_high", "corrupt_future",
                       "followup_min", "followup_max", "event",  # Survival parameters
                       "7", "8", "9", "96", "97", "98", "99",  # Missing codes
                       "-7", "-8", "-9")  # Negative missing codes

--- a/R/validate_mockdata_extensions.R
+++ b/R/validate_mockdata_extensions.R
@@ -48,6 +48,7 @@ validate_mockdata_metadata <- function(variables_path, variable_details_path, mo
   # Load data
   variables <- read.csv(variables_path, stringsAsFactors = FALSE, check.names = FALSE)
   variable_details <- read.csv(variable_details_path, stringsAsFactors = FALSE, check.names = FALSE)
+  variables <- .migrate_garbage_aliases(variables)
 
   # 1. UID validation (numeric-only pattern)
   result$uid_validation <- validate_uids(variables, variable_details)
@@ -180,7 +181,7 @@ validate_rtype <- function(variables) {
   valid_rtypes <- c("integer", "double", "factor", "logical", "character", "date")
 
   if ("rType" %in% names(variables)) {
-    non_empty_rtypes <- variables$rType[!is.na(variables$rType) & variables$rType != ""]
+    non_empty_rtypes <- tolower(variables$rType[!is.na(variables$rType) & variables$rType != ""])
 
     if (length(non_empty_rtypes) > 0) {
       invalid_rtypes <- setdiff(unique(non_empty_rtypes), valid_rtypes)
@@ -331,6 +332,40 @@ validate_garbage <- function(variables) {
         result$errors <- c(result$errors,
           paste("garbage_high_prop values must be 0-1:", paste(invalid, collapse = ", ")))
       }
+    }
+  }
+
+  # Check combined garbage proportions. The generator applies low garbage first,
+  # then high garbage to remaining valid values; totals above 1 cannot be
+  # represented without truncating the second pass.
+  if ("garbage_low_prop" %in% names(variables) || "garbage_high_prop" %in% names(variables)) {
+    garbage_low <- if ("garbage_low_prop" %in% names(variables)) {
+      suppressWarnings(as.numeric(variables$garbage_low_prop))
+    } else {
+      rep(0, nrow(variables))
+    }
+    garbage_high <- if ("garbage_high_prop" %in% names(variables)) {
+      suppressWarnings(as.numeric(variables$garbage_high_prop))
+    } else {
+      rep(0, nrow(variables))
+    }
+
+    garbage_low[is.na(garbage_low)] <- 0
+    garbage_high[is.na(garbage_high)] <- 0
+    garbage_total <- garbage_low + garbage_high
+    invalid_total <- which(garbage_total > 1)
+
+    if (length(invalid_total) > 0) {
+      labels <- if ("variable" %in% names(variables)) {
+        variables$variable[invalid_total]
+      } else {
+        invalid_total
+      }
+      result$errors <- c(result$errors,
+        paste(
+          "garbage_low_prop + garbage_high_prop must be <= 1 for each variable:",
+          paste(labels, collapse = ", ")
+        ))
     }
   }
 

--- a/R/validate_mockdata_extensions.R
+++ b/R/validate_mockdata_extensions.R
@@ -178,7 +178,7 @@ validate_uids <- function(variables, variable_details) {
 validate_rtype <- function(variables) {
   result <- list(errors = character(0), warnings = character(0), info = character(0))
 
-  valid_rtypes <- c("integer", "double", "factor", "logical", "character", "date")
+  valid_rtypes <- c("integer", "double", "numeric", "factor", "logical", "character", "date")
 
   if ("rType" %in% names(variables)) {
     non_empty_rtypes <- tolower(variables$rType[!is.na(variables$rType) & variables$rType != ""])
@@ -293,7 +293,12 @@ validate_garbage <- function(variables) {
     non_empty <- variables$garbage_low_prop[!is.na(variables$garbage_low_prop) &
                                                variables$garbage_low_prop != ""]
     if (length(non_empty) > 0) {
-      garbage_low <- as.numeric(non_empty)
+      garbage_low <- suppressWarnings(as.numeric(non_empty))
+      not_numeric <- non_empty[is.na(garbage_low)]
+      if (length(not_numeric) > 0) {
+        result$errors <- c(result$errors,
+          paste("garbage_low_prop values must be numeric:", paste(not_numeric, collapse = ", ")))
+      }
       invalid <- garbage_low[garbage_low < 0 | garbage_low > 1]
 
       if (length(invalid) > 0) {
@@ -325,7 +330,12 @@ validate_garbage <- function(variables) {
     non_empty <- variables$garbage_high_prop[!is.na(variables$garbage_high_prop) &
                                                 variables$garbage_high_prop != ""]
     if (length(non_empty) > 0) {
-      garbage_high <- as.numeric(non_empty)
+      garbage_high <- suppressWarnings(as.numeric(non_empty))
+      not_numeric <- non_empty[is.na(garbage_high)]
+      if (length(not_numeric) > 0) {
+        result$errors <- c(result$errors,
+          paste("garbage_high_prop values must be numeric:", paste(not_numeric, collapse = ", ")))
+      }
       invalid <- garbage_high[garbage_high < 0 | garbage_high > 1]
 
       if (length(invalid) > 0) {
@@ -335,9 +345,9 @@ validate_garbage <- function(variables) {
     }
   }
 
-  # Check combined garbage proportions. The generator applies low garbage first,
-  # then high garbage to remaining valid values; totals above 1 cannot be
-  # represented without truncating the second pass.
+  # Check combined garbage proportions. Low and high proportions are each
+  # interpreted relative to the original valid pool; totals above 1 truncate the
+  # second pass because there are not enough remaining valid rows.
   if ("garbage_low_prop" %in% names(variables) || "garbage_high_prop" %in% names(variables)) {
     garbage_low <- if ("garbage_low_prop" %in% names(variables)) {
       suppressWarnings(as.numeric(variables$garbage_low_prop))

--- a/tests/testthat/test-critical-regressions.R
+++ b/tests/testthat/test-critical-regressions.R
@@ -195,3 +195,223 @@ test_that("import_from_recodeflow uses exact databaseStart tokens", {
   expect_equal(imported$config$variable, "age_2017")
   expect_equal(imported$details$variable, "age_2017")
 })
+
+test_that("create_mock_data matches enabled as an exact role token", {
+  variables <- data.frame(
+    variable = c("age", "visits"),
+    variableType = c("Continuous", "Continuous"),
+    rType = c("integer", "integer"),
+    role = c("enabled", "disabled"),
+    stringsAsFactors = FALSE
+  )
+
+  variable_details <- data.frame(
+    variable = c("age", "visits"),
+    recStart = c("[18,85]", "[0,20]"),
+    recEnd = c("copy", "copy"),
+    proportion = c(1, 1),
+    stringsAsFactors = FALSE
+  )
+
+  result <- create_mock_data(
+    databaseStart = "study",
+    variables = variables,
+    variable_details = variable_details,
+    n = 5,
+    seed = 1
+  )
+
+  expect_equal(names(result), "age")
+})
+
+test_that("extract_proportions uses recEnd rather than numeric code heuristics for missingness", {
+  details <- data.frame(
+    variable = "visits",
+    recStart = c("7", "17", "27", "99"),
+    recEnd = c("7", "17", "27", "NA::b"),
+    proportion = c(0.25, 0.25, 0.25, 0.25),
+    stringsAsFactors = FALSE
+  )
+
+  props <- extract_proportions(details, variable_name = "visits")
+
+  expect_equal(props$categories, c("7", "17", "27"))
+  expect_equal(names(props$missing), "99")
+  expect_equal(props$valid, 0.75)
+})
+
+test_that("create_mock_data fallback mode works when variable_details is NULL", {
+  variables <- data.frame(
+    variable = c("smoking", "age", "interview_date"),
+    variableType = c("Categorical", "Continuous", "Date"),
+    rType = c("factor", "integer", "date"),
+    role = "enabled",
+    stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    result <- create_mock_data(
+      databaseStart = "study",
+      variables = variables,
+      variable_details = NULL,
+      n = 5,
+      seed = 1
+    ),
+    "No variable_details rows found"
+  )
+
+  expect_equal(names(result), variables$variable)
+  expect_equal(nrow(result), 5)
+  expect_s3_class(result$smoking, "factor")
+  expect_type(result$age, "integer")
+  expect_s3_class(result$interview_date, "Date")
+})
+
+test_that("create_mock_data validate controls unknown rType failures", {
+  variables <- data.frame(
+    variable = "mystery",
+    variableType = "Unknown",
+    rType = "unsupported",
+    role = "enabled",
+    stringsAsFactors = FALSE
+  )
+
+  expect_error(
+    create_mock_data(
+      databaseStart = "study",
+      variables = variables,
+      variable_details = NULL,
+      n = 5,
+      validate = TRUE
+    ),
+    "Unknown variable type"
+  )
+
+  expect_warning(
+    result <- create_mock_data(
+      databaseStart = "study",
+      variables = variables,
+      variable_details = NULL,
+      n = 5,
+      validate = FALSE
+    ),
+    "Unknown variable type"
+  )
+  expect_equal(nrow(result), 5)
+  expect_equal(ncol(result), 0)
+})
+
+test_that("rType defaults and validation use lowercase date consistently", {
+  details <- data.frame(
+    variable = "interview_date",
+    typeEnd = "date",
+    recStart = "[2020-01-01,2020-12-31]",
+    stringsAsFactors = FALSE
+  )
+
+  defaulted <- apply_rtype_defaults(details)
+  expect_equal(defaulted$rType, "date")
+
+  existing <- details
+  existing$rType <- "Date"
+  normalized <- apply_rtype_defaults(existing)
+  expect_equal(normalized$rType, "date")
+
+  variables <- data.frame(
+    variable = "interview_date",
+    rType = "Date",
+    stringsAsFactors = FALSE
+  )
+  result <- MockData:::validate_rtype(variables)
+  expect_length(result$errors, 0)
+})
+
+test_that("corrupt garbage columns are migrated with a deprecation warning", {
+  variables <- data.frame(
+    variable = "age",
+    variableType = "Continuous",
+    rType = "integer",
+    role = "enabled",
+    corrupt_high_prop = 1,
+    corrupt_high_range = "[150,150]",
+    stringsAsFactors = FALSE
+  )
+  details <- data.frame(
+    variable = "age",
+    recStart = "[18,20]",
+    recEnd = "copy",
+    proportion = 1,
+    stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    result <- create_mock_data(
+      databaseStart = "study",
+      variables = variables,
+      variable_details = details,
+      n = 5,
+      seed = 1
+    ),
+    "corrupt_\\* garbage columns are deprecated"
+  )
+
+  expect_true(all(result$age == 150))
+})
+
+test_that("read_mock_data_config migrates corrupt garbage columns", {
+  config_file <- tempfile(fileext = ".csv")
+  write.csv(data.frame(
+    variable = "age",
+    role = "enabled",
+    variableType = "Continuous",
+    rType = "integer",
+    position = 1,
+    corrupt_low_prop = 0.1,
+    corrupt_low_range = "[-1,0]",
+    stringsAsFactors = FALSE
+  ), config_file, row.names = FALSE)
+
+  expect_warning(
+    config <- read_mock_data_config(config_file, validate = TRUE),
+    "corrupt_\\* garbage columns are deprecated"
+  )
+
+  expect_equal(config$garbage_low_prop, 0.1)
+  expect_equal(config$garbage_low_range, "[-1,0]")
+})
+
+test_that("read_mock_data_config_details migrates corrupt recStart values", {
+  details_file <- tempfile(fileext = ".csv")
+  write.csv(data.frame(
+    variable = "age",
+    recStart = c("[18,20]", "corrupt_high"),
+    recEnd = c("copy", "copy"),
+    proportion = c(1, 0.1),
+    stringsAsFactors = FALSE
+  ), details_file, row.names = FALSE)
+
+  expect_warning(
+    details <- read_mock_data_config_details(details_file, validate = TRUE),
+    "corrupt_\\* recStart values are deprecated"
+  )
+
+  expect_true("garbage_high" %in% details$recStart)
+})
+
+test_that("garbage validation rejects low and high proportions above one", {
+  variables <- data.frame(
+    variable = "age",
+    garbage_low_prop = 0.6,
+    garbage_low_range = "[-1,0]",
+    garbage_high_prop = 0.6,
+    garbage_high_range = "[150,200]",
+    stringsAsFactors = FALSE
+  )
+
+  result <- MockData:::validate_garbage(variables)
+
+  expect_match(
+    result$errors,
+    "garbage_low_prop \\+ garbage_high_prop must be <= 1"
+  )
+})

--- a/tests/testthat/test-critical-regressions.R
+++ b/tests/testthat/test-critical-regressions.R
@@ -224,6 +224,34 @@ test_that("create_mock_data matches enabled as an exact role token", {
   expect_equal(names(result), "age")
 })
 
+test_that("create_mock_data supports whitespace-separated role tokens", {
+  variables <- data.frame(
+    variable = c("age", "visits"),
+    variableType = c("Continuous", "Continuous"),
+    rType = c("integer", "integer"),
+    role = c("enabled predictor", "disabled"),
+    stringsAsFactors = FALSE
+  )
+
+  variable_details <- data.frame(
+    variable = c("age", "visits"),
+    recStart = c("[18,85]", "[0,20]"),
+    recEnd = c("copy", "copy"),
+    proportion = c(1, 1),
+    stringsAsFactors = FALSE
+  )
+
+  result <- create_mock_data(
+    databaseStart = "study",
+    variables = variables,
+    variable_details = variable_details,
+    n = 5,
+    seed = 1
+  )
+
+  expect_equal(names(result), "age")
+})
+
 test_that("extract_proportions uses recEnd rather than numeric code heuristics for missingness", {
   details <- data.frame(
     variable = "visits",
@@ -319,7 +347,7 @@ test_that("rType defaults and validation use lowercase date consistently", {
 
   variables <- data.frame(
     variable = "interview_date",
-    rType = "Date",
+    rType = c("Date", "numeric"),
     stringsAsFactors = FALSE
   )
   result <- MockData:::validate_rtype(variables)
@@ -414,4 +442,47 @@ test_that("garbage validation rejects low and high proportions above one", {
     result$errors,
     "garbage_low_prop \\+ garbage_high_prop must be <= 1"
   )
+})
+
+test_that("garbage validation rejects non-numeric proportions", {
+  variables <- data.frame(
+    variable = "age",
+    garbage_low_prop = "high",
+    garbage_low_range = "[-1,0]",
+    garbage_high_prop = "0,5",
+    garbage_high_range = "[150,200]",
+    stringsAsFactors = FALSE
+  )
+
+  result <- MockData:::validate_garbage(variables)
+
+  expect_true(any(grepl("garbage_low_prop values must be numeric", result$errors)))
+  expect_true(any(grepl("garbage_high_prop values must be numeric", result$errors)))
+})
+
+test_that("create_mock_data summarizes skipped variables when validate is FALSE", {
+  variables <- data.frame(
+    variable = "mystery",
+    variableType = "Unknown",
+    rType = "unsupported",
+    role = "enabled",
+    stringsAsFactors = FALSE
+  )
+
+  expect_message(
+    expect_warning(
+      result <- create_mock_data(
+        databaseStart = "study",
+        variables = variables,
+        variable_details = NULL,
+        n = 5,
+        validate = FALSE
+      ),
+      "Unknown variable type"
+    ),
+    "Skipped variables"
+  )
+
+  expect_equal(nrow(result), 5)
+  expect_equal(ncol(result), 0)
 })

--- a/tests/testthat/test-survival-garbage-deprecation.R
+++ b/tests/testthat/test-survival-garbage-deprecation.R
@@ -26,7 +26,7 @@ test_that("create_wide_survival_data() shows deprecation warning for prop_garbag
       seed = 123,
       prop_garbage = 0.03  # This should trigger warning
     ),
-    regexp = "deprecated as of v0.3.1"
+    regexp = "deprecated as of v0.3.0"
   )
 })
 


### PR DESCRIPTION
## Summary

This PR fixes the remaining v0.3 critical metadata/generation regressions before the broader architecture spike.

- Use exact role-token matching so `disabled` no longer matches `enabled`
- Use `recEnd` as the authoritative missing-code classifier instead of numeric heuristics
- Make `create_mock_data(variable_details = NULL)` fallback mode work across categorical, continuous, and date variables
- Make `validate = TRUE` fail fast for unsupported rType/generator errors, with `validate = FALSE` preserving warn-and-skip behavior
- Normalize rType handling around lowercase values, including `date`
- Migrate legacy `corrupt_*` garbage columns/rows to `garbage_*` with deprecation warnings
- Validate that `garbage_low_prop + garbage_high_prop <= 1`
- Clean survival garbage deprecation text/examples from v0.3.1 drift to v0.3.0
- Add critical regression coverage for the above

## Verification

- `Rscript --vanilla -e 'devtools::load_all(quiet = TRUE); testthat::test_dir("tests/testthat", reporter = "summary")'` passed with 2 existing skips and 34 existing warnings.
- `env RENV_CONFIG_AUTOLOADER_ENABLED=false R CMD INSTALL --use-vanilla --no-byte-compile --no-staged-install --no-docs --no-html --no-help --no-test-load --library=/private/tmp/mockdata-install-lib .` passed with `* DONE (MockData)`.
- `env RENV_CONFIG_AUTOLOADER_ENABLED=false quarto render vignettes/getting-started.qmd --to gfm` passed, verifying the QMD examples execute.

## Notes

Local ordinary R startup currently hangs through `renv/activate.R`; install/render verification used `RENV_CONFIG_AUTOLOADER_ENABLED=false`. HTML rendering of `getting-started.qmd` then gets through all R chunks but fails in local Quarto Sass/Deno KV cache with `unable to open database file`. This appears to be local environment/tooling, not a MockData example failure.