### PR TITLE
Code-quality fixes: dedupe loaders and dispatch, loud failure modes, runnable examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,10 +25,10 @@ VignetteBuilder: quarto
 Depends:
     R (>= 4.2.0)
 Imports:
-    stats,
-    dplyr
+    stats
 Suggests:
     testthat (>= 3.0.0),
+    dplyr,
     readr,
     stringr,
     lubridate,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,11 +3,16 @@
 ## Breaking changes
 
 - `create_cat_var()`, `create_con_var()`, and `create_date_var()` now stop
-  with an error when the requested variable is not found in `variables`
-  metadata, instead of warning and returning `NULL`. Within
-  `create_mock_data()`, set `validate = FALSE` to convert these errors to
-  warn-and-skip behaviour. Duplicate `variables` rows for the same variable
-  now produce a warning before the first row is used.
+  with the error `Variable '<name>' not found in variables metadata` when the
+  requested variable is absent, instead of warning and returning `NULL`. This
+  affects direct generator calls and `create_wide_survival_data()` (a
+  misspelled date-variable name now errors instead of being skipped with a
+  warning). `create_mock_data()` itself derives variable names from the
+  `variables` metadata, so it cannot trigger this error; its `validate = FALSE`
+  flag continues to convert any generator error to warn-and-skip on the legacy
+  path. Duplicate `variables` rows for the same variable now produce a warning
+  in the legacy `create_*` path before the first row is used (the v0.4
+  `mock_spec` path already errors on duplicate names).
 
 ## Development
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
   path. Duplicate `variables` rows for the same variable now produce a warning
   in the legacy `create_*` path before the first row is used (the v0.4
   `mock_spec` path already errors on duplicate names).
+- `create_mock_data()` error messages for missing metadata files changed from
+  `Configuration file does not exist:` / `Details file does not exist:` to
+  `variables file does not exist:` / `variable_details file does not exist:`.
 
 ## Development
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # MockData 0.4.0
 
+## Breaking changes
+
+- `create_cat_var()`, `create_con_var()`, and `create_date_var()` now stop
+  with an error when the requested variable is not found in `variables`
+  metadata, instead of warning and returning `NULL`. Within
+  `create_mock_data()`, set `validate = FALSE` to convert these errors to
+  warn-and-skip behaviour. Duplicate `variables` rows for the same variable
+  now produce a warning before the first row is used.
+
 ## Development
 
 - Started the v0.4 production refactor around a normalized `mock_spec`

--- a/R/add_garbage.R
+++ b/R/add_garbage.R
@@ -98,16 +98,8 @@
 #'   )
 #' vars_with_garbage
 #'
-#' \dontrun{
-#' # Generate data with garbage
-#' mock_data <- create_mock_data(
-#'   databaseStart = "minimal-example",
-#'   variables = vars_with_garbage,
-#'   variable_details = variable_details,
-#'   n = 1000,
-#'   seed = 123
-#' )
-#' }
+#' # Pass the result as the `variables` argument of create_mock_data() —
+#' # see ?create_mock_data.
 add_garbage <- function(variables, var,
                         garbage_low_prop = NULL, garbage_low_range = NULL,
                         garbage_high_prop = NULL, garbage_high_range = NULL) {

--- a/R/add_garbage.R
+++ b/R/add_garbage.R
@@ -82,31 +82,27 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
-#' # Load metadata
-#' variables <- read.csv(
-#'   system.file("extdata/minimal-example/variables.csv",
-#'     package = "MockData"),
-#'   stringsAsFactors = FALSE, check.names = FALSE
+#' variables <- data.frame(
+#'   variable = c("age", "smoking"),
+#'   variableType = c("Continuous", "Categorical"),
+#'   stringsAsFactors = FALSE
 #' )
 #'
-#' # Add garbage to age (high-range only)
-#' vars <- add_garbage(variables, "age",
-#'   garbage_high_prop = 0.03, garbage_high_range = "[150, 200]")
+#' # Add high-range garbage to age and low-range garbage to smoking
+#' vars_with_garbage <- variables |>
+#'   add_garbage("age",
+#'     garbage_high_prop = 0.03, garbage_high_range = "[150, 200]"
+#'   ) |>
+#'   add_garbage("smoking",
+#'     garbage_low_prop = 0.02, garbage_low_range = "[-2, 0]"
+#'   )
+#' vars_with_garbage
 #'
-#' # Add garbage to smoking (low-range only)
-#' vars <- add_garbage(vars, "smoking",
-#'   garbage_low_prop = 0.02, garbage_low_range = "[-2, 0]")
-#'
-#' # Add garbage to BMI (two-sided invalid values)
-#' vars <- add_garbage(vars, "BMI",
-#'   garbage_low_prop = 0.02, garbage_low_range = "[-10, 15)",
-#'   garbage_high_prop = 0.01, garbage_high_range = "[60, 150]")
-#'
+#' \dontrun{
 #' # Generate data with garbage
 #' mock_data <- create_mock_data(
 #'   databaseStart = "minimal-example",
-#'   variables = vars,
+#'   variables = vars_with_garbage,
 #'   variable_details = variable_details,
 #'   n = 1000,
 #'   seed = 123

--- a/R/create_cat_var.R
+++ b/R/create_cat_var.R
@@ -103,10 +103,12 @@
 #'   n = 100,
 #'   seed = 123
 #' )
-#' # Missing codes (recEnd = "NA::b") are included based on proportions
+#' # Code 7 ("Don't know") is an NA::b missing code, generated at its
+#' # configured proportion alongside the substantive categories.
 #' table(smoking$smoking)
 #'
 #' \dontrun{
+#' # Not run: requires your own metadata CSV files
 #' # With file paths instead of data frames
 #' result <- create_cat_var(
 #'   var = "smoking",

--- a/R/create_cat_var.R
+++ b/R/create_cat_var.R
@@ -31,7 +31,7 @@
 #'
 #' @return data.frame with one column (the generated categorical variable), or NULL if:
 #'   \itemize{
-#'     \item Variable already exists in df_mock
+#'     \item Variable already exists in df_mock (a message is emitted)
 #'     \item No valid categories found in variable_details
 #'   }
 #'
@@ -139,7 +139,7 @@ create_cat_var <- function(var,
   # ========== INTERNAL FILTERING (recodeflow pattern) ==========
 
   # Filter variables for this var
-  var_row <- variables[variables$variable == var, ]
+  var_row <- variables[variables$variable == var, , drop = FALSE]
 
   if (nrow(var_row) == 0) {
     stop("Variable '", var, "' not found in variables metadata", call. = FALSE)
@@ -166,15 +166,18 @@ create_cat_var <- function(var,
          databaseStart,
          allow_empty = TRUE
        )),
+      ,
+      drop = FALSE
     ]
   } else {
     # Fallback: no databaseStart filtering (for simple configs)
-    details_subset <- variable_details[variable_details$variable == var, ]
+    details_subset <- variable_details[variable_details$variable == var, , drop = FALSE]
   }
 
   # ========== CHECK IF VARIABLE ALREADY EXISTS ==========
 
   if (!is.null(df_mock) && var %in% names(df_mock)) {
+    message("Variable '", var, "' already exists in df_mock; skipping generation.")
     return(NULL)
   }
 

--- a/R/create_cat_var.R
+++ b/R/create_cat_var.R
@@ -31,10 +31,12 @@
 #'
 #' @return data.frame with one column (the generated categorical variable), or NULL if:
 #'   \itemize{
-#'     \item Variable not found in metadata
 #'     \item Variable already exists in df_mock
 #'     \item No valid categories found in variable_details
 #'   }
+#'
+#'   Errors if the variable is not found in the variables metadata. Warns and
+#'   uses the first row if multiple variables rows match.
 #'
 #' @details
 #' **v0.3.0 API**: This function now accepts full metadata data frames and filters
@@ -146,8 +148,8 @@ create_cat_var <- function(var,
   }
 
   if (nrow(var_row) > 1) {
-    warning("Multiple variables rows found for '", var,
-            "' (", nrow(var_row), " rows); using the first row.",
+    warning("Multiple rows found for '", var, "' in variables metadata (",
+            nrow(var_row), " rows); using the first row.",
             call. = FALSE)
     var_row <- var_row[1, ]
   }

--- a/R/create_cat_var.R
+++ b/R/create_cat_var.R
@@ -133,12 +133,8 @@ create_cat_var <- function(var,
   # ========== PARAMETER VALIDATION ==========
 
   # Load metadata from file paths if needed
-  if (is.character(variables) && length(variables) == 1) {
-    variables <- read.csv(variables, stringsAsFactors = FALSE, check.names = FALSE)
-  }
-  if (is.character(variable_details) && length(variable_details) == 1) {
-    variable_details <- read.csv(variable_details, stringsAsFactors = FALSE, check.names = FALSE)
-  }
+  variables <- .load_metadata_df(variables, "variables")
+  variable_details <- .load_metadata_df(variable_details, "variable_details")
 
   # ========== INTERNAL FILTERING (recodeflow pattern) ==========
 

--- a/R/create_cat_var.R
+++ b/R/create_cat_var.R
@@ -142,12 +142,13 @@ create_cat_var <- function(var,
   var_row <- variables[variables$variable == var, ]
 
   if (nrow(var_row) == 0) {
-    warning(paste0("Variable '", var, "' not found in variables metadata"))
-    return(NULL)
+    stop("Variable '", var, "' not found in variables metadata", call. = FALSE)
   }
 
-  # Take first row if multiple matches
   if (nrow(var_row) > 1) {
+    warning("Multiple variables rows found for '", var,
+            "' (", nrow(var_row), " rows); using the first row.",
+            call. = FALSE)
     var_row <- var_row[1, ]
   }
 
@@ -188,7 +189,7 @@ create_cat_var <- function(var,
       "No variable_details rows found for variable '", var,
       "' and databaseStart '", databaseStart,
       "'. Using fallback categories c('1', '2')."
-    ))
+    ), call. = FALSE)
     # Generate simple 2-category variable with uniform distribution
     values <- sample(c("1", "2"), size = n, replace = TRUE)
     # Fallback still honors rType so output contracts match configured metadata.
@@ -219,7 +220,7 @@ create_cat_var <- function(var,
 
   # Check if we have valid categories
   if (length(props$categories) == 0) {
-    warning(paste0("No valid categories found for ", var))
+    warning(paste0("No valid categories found for ", var), call. = FALSE)
     return(NULL)
   }
 

--- a/R/create_cat_var.R
+++ b/R/create_cat_var.R
@@ -78,39 +78,35 @@
 #' }
 #'
 #' @examples
-#' \dontrun{
-#' # Basic usage with metadata data frames
+#' variables <- data.frame(
+#'   variable = "smoking",
+#'   variableType = "Categorical",
+#'   rType = "factor",
+#'   stringsAsFactors = FALSE
+#' )
+#' variable_details <- data.frame(
+#'   variable = "smoking",
+#'   recStart = c("1", "2", "3", "7"),
+#'   recEnd = c("1", "2", "3", "NA::b"),
+#'   proportion = c(0.5, 0.3, 0.17, 0.03),
+#'   catLabel = c(
+#'     "Never smoker", "Former smoker", "Current smoker", "Don't know"
+#'   ),
+#'   stringsAsFactors = FALSE
+#' )
+#'
 #' smoking <- create_cat_var(
 #'   var = "smoking",
-#'   databaseStart = "cchs2001_p",
+#'   databaseStart = "example",
 #'   variables = variables,
 #'   variable_details = variable_details,
-#'   n = 1000,
+#'   n = 100,
 #'   seed = 123
 #' )
+#' # Missing codes (recEnd = "NA::b") are included based on proportions
+#' table(smoking$smoking)
 #'
-#' # Expected output: data.frame with 1000 rows, 1 column ("smoking")
-#' # Values: Factor with levels from metadata (e.g., "1", "2", "3", "7")
-#' # Distribution: Based on proportions in variable_details
-#' # Example:
-#' #   smoking
-#' # 1       1
-#' # 2       3
-#' # 3       2
-#' # 4       1
-#' # 5       7
-#' # ...
-#'
-#' # With missing data (uses proportions from metadata)
-#' smoking <- create_cat_var(
-#'   var = "smoking",
-#'   databaseStart = "cchs2001_p",
-#'   variables = variables,
-#'   variable_details = variable_details,
-#'   n = 1000
-#' )
-#' # Missing codes (recEnd = "NA::b") automatically included based on proportions
-#'
+#' \dontrun{
 #' # With file paths instead of data frames
 #' result <- create_cat_var(
 #'   var = "smoking",

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -106,6 +106,7 @@
 #' head(age)
 #'
 #' \dontrun{
+#' # Not run: requires your own metadata CSV files
 #' # With file paths instead of data frames
 #' result <- create_con_var(
 #'   var = "BMI",

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -30,8 +30,10 @@
 #' @param n integer. Number of observations to generate.
 #' @param seed integer. Optional. Random seed for reproducibility.
 #'
-#' @return data.frame with one column (the generated continuous variable), or NULL if
-#'   the variable already exists in df_mock.
+#' @return data.frame with one column (the generated continuous variable), or NULL if:
+#'   \itemize{
+#'     \item Variable already exists in df_mock
+#'   }
 #'
 #'   Errors if the variable is not found in the variables metadata. Warns and
 #'   uses the first row if multiple variables rows match.

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -139,12 +139,13 @@ create_con_var <- function(var,
   var_row <- variables[variables$variable == var, ]
 
   if (nrow(var_row) == 0) {
-    warning(paste0("Variable '", var, "' not found in variables metadata"))
-    return(NULL)
+    stop("Variable '", var, "' not found in variables metadata", call. = FALSE)
   }
 
-  # Take first row if multiple matches
   if (nrow(var_row) > 1) {
+    warning("Multiple variables rows found for '", var,
+            "' (", nrow(var_row), " rows); using the first row.",
+            call. = FALSE)
     var_row <- var_row[1, ]
   }
 
@@ -185,7 +186,7 @@ create_con_var <- function(var,
       "No variable_details rows found for variable '", var,
       "' and databaseStart '", databaseStart,
       "'. Using fallback uniform range [0, 100]."
-    ))
+    ), call. = FALSE)
     values <- runif(n, min = 0, max = 100)
     # Fallback still honors rType so output contracts match configured metadata.
     if ("rType" %in% names(var_row)) {
@@ -286,13 +287,13 @@ create_con_var <- function(var,
         "Variable '", var,
         "' requested normal distribution but mean and/or sd are missing. ",
         "Using uniform distribution instead."
-      ))
+      ), call. = FALSE)
     } else if (distribution_type == "exponential") {
       warning(paste0(
         "Variable '", var,
         "' requested exponential distribution but rate is missing. ",
         "Using uniform distribution instead."
-      ))
+      ), call. = FALSE)
     }
 
     # Uniform distribution (default)

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -81,30 +81,31 @@
 #' }
 #'
 #' @examples
-#' \dontrun{
-#' # Basic usage with metadata data frames
-#' age <- create_con_var(
-#'   var = "age",
-#'   databaseStart = "cchs2001_p",
-#'   variables = variables,
-#'   variable_details = variable_details,
-#'   n = 1000,
-#'   seed = 123
+#' variables <- data.frame(
+#'   variable = "age",
+#'   variableType = "Continuous",
+#'   rType = "integer",
+#'   stringsAsFactors = FALSE
+#' )
+#' variable_details <- data.frame(
+#'   variable = "age",
+#'   recStart = "[18,85]",
+#'   recEnd = "copy",
+#'   proportion = 1,
+#'   stringsAsFactors = FALSE
 #' )
 #'
-#' # Expected output: data.frame with 1000 rows, 1 column ("age")
-#' # Values: Numeric based on distribution in metadata
-#' # Example for age with normal(50, 15):
-#' #   age
-#' # 1  45
-#' # 2  52
-#' # 3  48
-#' # 4  61
-#' # 5  39
-#' # ...
-#' # Distribution: Normal(mean=50, sd=15), clipped to [18,100]
-#' # Type: Integer (if rType="integer" in metadata)
+#' age <- create_con_var(
+#'   var = "age",
+#'   databaseStart = "example",
+#'   variables = variables,
+#'   variable_details = variable_details,
+#'   n = 100,
+#'   seed = 123
+#' )
+#' head(age)
 #'
+#' \dontrun{
 #' # With file paths instead of data frames
 #' result <- create_con_var(
 #'   var = "BMI",

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -30,12 +30,11 @@
 #' @param n integer. Number of observations to generate.
 #' @param seed integer. Optional. Random seed for reproducibility.
 #'
-#' @return data.frame with one column (the generated continuous variable), or NULL if:
-#'   \itemize{
-#'     \item Variable not found in metadata
-#'     \item Variable already exists in df_mock
-#'     \item No valid range found in variable_details
-#'   }
+#' @return data.frame with one column (the generated continuous variable), or NULL if
+#'   the variable already exists in df_mock.
+#'
+#'   Errors if the variable is not found in the variables metadata. Warns and
+#'   uses the first row if multiple variables rows match.
 #'
 #' @details
 #' **v0.3.0 API**: This function now accepts full metadata data frames and filters
@@ -143,8 +142,8 @@ create_con_var <- function(var,
   }
 
   if (nrow(var_row) > 1) {
-    warning("Multiple variables rows found for '", var,
-            "' (", nrow(var_row), " rows); using the first row.",
+    warning("Multiple rows found for '", var, "' in variables metadata (",
+            nrow(var_row), " rows); using the first row.",
             call. = FALSE)
     var_row <- var_row[1, ]
   }

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -30,10 +30,8 @@
 #' @param n integer. Number of observations to generate.
 #' @param seed integer. Optional. Random seed for reproducibility.
 #'
-#' @return data.frame with one column (the generated continuous variable), or NULL if:
-#'   \itemize{
-#'     \item Variable already exists in df_mock
-#'   }
+#' @return data.frame with one column (the generated continuous variable), or
+#'   NULL (with a message) if the variable already exists in df_mock.
 #'
 #'   Errors if the variable is not found in the variables metadata. Warns and
 #'   uses the first row if multiple variables rows match.
@@ -139,7 +137,7 @@ create_con_var <- function(var,
   # ========== INTERNAL FILTERING (recodeflow pattern) ==========
 
   # Filter variables for this var
-  var_row <- variables[variables$variable == var, ]
+  var_row <- variables[variables$variable == var, , drop = FALSE]
 
   if (nrow(var_row) == 0) {
     stop("Variable '", var, "' not found in variables metadata", call. = FALSE)
@@ -166,15 +164,18 @@ create_con_var <- function(var,
          databaseStart,
          allow_empty = TRUE
        )),
+      ,
+      drop = FALSE
     ]
   } else {
     # Fallback: no databaseStart filtering (for simple configs)
-    details_subset <- variable_details[variable_details$variable == var, ]
+    details_subset <- variable_details[variable_details$variable == var, , drop = FALSE]
   }
 
   # ========== CHECK IF VARIABLE ALREADY EXISTS ==========
 
   if (!is.null(df_mock) && var %in% names(df_mock)) {
+    message("Variable '", var, "' already exists in df_mock; skipping generation.")
     return(NULL)
   }
 

--- a/R/create_con_var.R
+++ b/R/create_con_var.R
@@ -130,12 +130,8 @@ create_con_var <- function(var,
   # ========== PARAMETER VALIDATION ==========
 
   # Load metadata from file paths if needed
-  if (is.character(variables) && length(variables) == 1) {
-    variables <- read.csv(variables, stringsAsFactors = FALSE, check.names = FALSE)
-  }
-  if (is.character(variable_details) && length(variable_details) == 1) {
-    variable_details <- read.csv(variable_details, stringsAsFactors = FALSE, check.names = FALSE)
-  }
+  variables <- .load_metadata_df(variables, "variables")
+  variable_details <- .load_metadata_df(variable_details, "variable_details")
 
   # ========== INTERNAL FILTERING (recodeflow pattern) ==========
 

--- a/R/create_date_var.R
+++ b/R/create_date_var.R
@@ -132,12 +132,8 @@ create_date_var <- function(var,
   # ========== PARAMETER VALIDATION ==========
 
   # Load metadata from file paths if needed
-  if (is.character(variables) && length(variables) == 1) {
-    variables <- read.csv(variables, stringsAsFactors = FALSE, check.names = FALSE)
-  }
-  if (is.character(variable_details) && length(variable_details) == 1) {
-    variable_details <- read.csv(variable_details, stringsAsFactors = FALSE, check.names = FALSE)
-  }
+  variables <- .load_metadata_df(variables, "variables")
+  variable_details <- .load_metadata_df(variable_details, "variable_details")
 
   # ========== INTERNAL FILTERING (recodeflow pattern) ==========
 

--- a/R/create_date_var.R
+++ b/R/create_date_var.R
@@ -33,7 +33,7 @@
 #'
 #' @return data.frame with one column (the generated date variable), or NULL if:
 #'   \itemize{
-#'     \item Variable already exists in df_mock
+#'     \item Variable already exists in df_mock (a message is emitted)
 #'     \item No valid date range found in variable_details, or the date
 #'       range cannot be parsed
 #'     \item Survival-variable preconditions are not met (e.g. df_mock lacks
@@ -143,7 +143,7 @@ create_date_var <- function(var,
   # ========== INTERNAL FILTERING (recodeflow pattern) ==========
 
   # Filter variables for this var
-  var_row <- variables[variables$variable == var, ]
+  var_row <- variables[variables$variable == var, , drop = FALSE]
 
   if (nrow(var_row) == 0) {
     stop("Variable '", var, "' not found in variables metadata", call. = FALSE)
@@ -170,15 +170,18 @@ create_date_var <- function(var,
          databaseStart,
          allow_empty = TRUE
        )),
+      ,
+      drop = FALSE
     ]
   } else {
     # Fallback: no databaseStart filtering (for simple configs)
-    details_subset <- variable_details[variable_details$variable == var, ]
+    details_subset <- variable_details[variable_details$variable == var, , drop = FALSE]
   }
 
   # ========== CHECK IF VARIABLE ALREADY EXISTS ==========
 
   if (!is.null(df_mock) && var %in% names(df_mock)) {
+    message("Variable '", var, "' already exists in df_mock; skipping generation.")
     return(NULL)
   }
 

--- a/R/create_date_var.R
+++ b/R/create_date_var.R
@@ -141,12 +141,13 @@ create_date_var <- function(var,
   var_row <- variables[variables$variable == var, ]
 
   if (nrow(var_row) == 0) {
-    warning(paste0("Variable '", var, "' not found in variables metadata"))
-    return(NULL)
+    stop("Variable '", var, "' not found in variables metadata", call. = FALSE)
   }
 
-  # Take first row if multiple matches
   if (nrow(var_row) > 1) {
+    warning("Multiple variables rows found for '", var,
+            "' (", nrow(var_row), " rows); using the first row.",
+            call. = FALSE)
     var_row <- var_row[1, ]
   }
 
@@ -211,7 +212,7 @@ create_date_var <- function(var,
       "No variable_details rows found for variable '", var,
       "' and databaseStart '", databaseStart,
       "'. Using fallback date range [2000-01-01, 2025-12-31]."
-    ))
+    ), call. = FALSE)
     # Default range: 2000-01-01 to 2025-12-31
     date_start <- as.Date("2000-01-01")
     date_end <- as.Date("2025-12-31")
@@ -243,7 +244,7 @@ create_date_var <- function(var,
         "Variable '", var, "' is a survival variable (has followup_min/max/event_prop), ",
         "but df_mock does not contain 'anchor_date' column. ",
         "Cannot generate survival dates without anchor dates."
-      ))
+      ), call. = FALSE)
       return(NULL)
     }
 
@@ -251,7 +252,7 @@ create_date_var <- function(var,
       warning(paste0(
         "Variable '", var, "': df_mock has ", nrow(df_mock), " rows but n=", n, ". ",
         "For survival variables, df_mock row count must match n."
-      ))
+      ), call. = FALSE)
       return(NULL)
     }
 
@@ -264,7 +265,7 @@ create_date_var <- function(var,
       warning(paste0(
         "Variable '", var, "': followup_min, followup_max, or event_prop is NA. ",
         "Cannot generate survival dates."
-      ))
+      ), call. = FALSE)
       return(NULL)
     }
 
@@ -275,7 +276,7 @@ create_date_var <- function(var,
       warning(paste0(
         "Variable '", var, "': Some anchor_date values are NA. ",
         "Cannot compute event dates."
-      ))
+      ), call. = FALSE)
       return(NULL)
     }
 
@@ -356,7 +357,7 @@ create_date_var <- function(var,
     }
 
     if (length(rec_start_values) == 0) {
-      warning(paste0("Variable '", var, "': No valid date range found in variable_details"))
+      warning(paste0("Variable '", var, "': No valid date range found in variable_details"), call. = FALSE)
       return(NULL)
     }
 
@@ -367,7 +368,7 @@ create_date_var <- function(var,
       warning(paste0(
         "Variable '", var, "': Cannot parse date range from recStart. ",
         "Expected format: [01JAN2001,31DEC2020], [2001-01-01,2020-12-31], or [2017-03-31,inf]"
-      ))
+      ), call. = FALSE)
       return(NULL)
     }
 

--- a/R/create_date_var.R
+++ b/R/create_date_var.R
@@ -33,10 +33,15 @@
 #'
 #' @return data.frame with one column (the generated date variable), or NULL if:
 #'   \itemize{
-#'     \item Variable not found in metadata
 #'     \item Variable already exists in df_mock
-#'     \item No valid date range found in variable_details
+#'     \item No valid date range found in variable_details, or the date
+#'       range cannot be parsed
+#'     \item Survival-variable preconditions are not met (e.g. df_mock lacks
+#'       an anchor_date column, or followup parameters are NA)
 #'   }
+#'
+#'   Errors if the variable is not found in the variables metadata. Warns and
+#'   uses the first row if multiple variables rows match.
 #'
 #' @details
 #' **v0.3.0 API**: This function now accepts full metadata data frames and filters
@@ -145,8 +150,8 @@ create_date_var <- function(var,
   }
 
   if (nrow(var_row) > 1) {
-    warning("Multiple variables rows found for '", var,
-            "' (", nrow(var_row), " rows); using the first row.",
+    warning("Multiple rows found for '", var, "' in variables metadata (",
+            nrow(var_row), " rows); using the first row.",
             call. = FALSE)
     var_row <- var_row[1, ]
   }

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -181,6 +181,9 @@
 #' see \code{vignette("reference-config", package = "MockData")}.
 #'
 #' @examples
+#' # The packaged minimal example includes deliberately messy metadata
+#' # (auto-normalized proportions, survival dates without an anchor): the
+#' # warnings it generates are expected and demonstrate MockData's diagnostics.
 #' mock_data <- create_mock_data(
 #'   databaseStart = "minimal-example",
 #'   variables = system.file("extdata/minimal-example/variables.csv",
@@ -192,18 +195,20 @@
 #'   n = 100,
 #'   seed = 123
 #' )
-#' head(mock_data)
 #' str(mock_data)
 #'
-#' \dontrun{
-#' # Fallback mode (uniform distributions, no variable_details)
+#' # Columns with straightforward metadata generate cleanly:
+#' head(mock_data[, c("age", "smoking", "interview_date")])
+#'
+#' # Fallback mode: no variable_details, simple default generators
 #' mock_data <- create_mock_data(
 #'   databaseStart = "minimal-example",
-#'   variables = "inst/extdata/minimal-example/variables.csv",
+#'   variables = system.file("extdata/minimal-example/variables.csv",
+#'     package = "MockData"
+#'   ),
 #'   variable_details = NULL,
 #'   n = 500
 #' )
-#' }
 #'
 #' @family generators
 #' @family mock generation APIs

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -343,6 +343,17 @@ create_mock_data <- function(databaseStart,
   df_mock <- data.frame(row.names = seq_len(n))
   skipped_vars <- character(0)
 
+  # rType → generator dispatch map. Keys double as the supported-rTypes list.
+  generator_map <- list(
+    factor    = create_cat_var,
+    character = create_cat_var,
+    logical   = create_cat_var,
+    integer   = create_con_var,
+    double    = create_con_var,
+    numeric   = create_con_var,
+    date      = create_date_var
+  )
+
   # Generate variables in order
   for (i in seq_len(nrow(enabled_vars))) {
     var_row <- enabled_vars[i, ]
@@ -368,15 +379,11 @@ create_mock_data <- function(databaseStart,
               var_name, " (", var_type, ")")
     }
 
-    supported_rtypes <- c(
-      "factor", "character", "logical", "integer", "double", "numeric", "date"
-    )
-
-    if (!var_type %in% supported_rtypes) {
+    if (!var_type %in% names(generator_map)) {
       msg <- paste0(
         "Unknown variable type '", var_type, "' for variable: ", var_name,
-        "\n  Supported rType values: factor, character, logical, integer, ",
-        "double, numeric, date"
+        "\n  Supported rType values: ",
+        paste(names(generator_map), collapse = ", ")
       )
 
       if (validate) {
@@ -389,9 +396,8 @@ create_mock_data <- function(databaseStart,
     } else {
       # Dispatch to type-specific generator
       var_data <- tryCatch({
-        switch(var_type,
-        # v0.2 schema rType values
-        "factor" = create_cat_var(
+        generator <- generator_map[[var_type]]
+        generator(
           var = var_name,
           databaseStart = databaseStart,
           variables = variables,
@@ -399,61 +405,6 @@ create_mock_data <- function(databaseStart,
           df_mock = df_mock,
           n = n,
           seed = NULL  # Global seed already set
-        ),
-        "character" = create_cat_var(
-          var = var_name,
-          databaseStart = databaseStart,
-          variables = variables,
-          variable_details = variable_details,
-          df_mock = df_mock,
-          n = n,
-          seed = NULL
-        ),
-        "logical" = create_cat_var(
-          var = var_name,
-          databaseStart = databaseStart,
-          variables = variables,
-          variable_details = variable_details,
-          df_mock = df_mock,
-          n = n,
-          seed = NULL
-        ),
-        "integer" = create_con_var(
-          var = var_name,
-          databaseStart = databaseStart,
-          variables = variables,
-          variable_details = variable_details,
-          df_mock = df_mock,
-          n = n,
-          seed = NULL
-        ),
-        "double" = create_con_var(
-          var = var_name,
-          databaseStart = databaseStart,
-          variables = variables,
-          variable_details = variable_details,
-          df_mock = df_mock,
-          n = n,
-          seed = NULL
-        ),
-        "numeric" = create_con_var(
-          var = var_name,
-          databaseStart = databaseStart,
-          variables = variables,
-          variable_details = variable_details,
-          df_mock = df_mock,
-          n = n,
-          seed = NULL
-        ),
-        "date" = create_date_var(
-          var = var_name,
-          databaseStart = databaseStart,
-          variables = variables,
-          variable_details = variable_details,
-          df_mock = df_mock,
-          n = n,
-          seed = NULL
-        )
         )
       }, error = function(e) {
         msg <- paste0("Error generating variable ", var_name, ": ", e$message)

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -181,30 +181,21 @@
 #' see \code{vignette("reference-config", package = "MockData")}.
 #'
 #' @examples
+#' mock_data <- create_mock_data(
+#'   databaseStart = "minimal-example",
+#'   variables = system.file("extdata/minimal-example/variables.csv",
+#'     package = "MockData"
+#'   ),
+#'   variable_details = system.file("extdata/minimal-example/variable_details.csv",
+#'     package = "MockData"
+#'   ),
+#'   n = 100,
+#'   seed = 123
+#' )
+#' head(mock_data)
+#' str(mock_data)
+#'
 #' \dontrun{
-#' # Basic usage with file paths
-#' mock_data <- create_mock_data(
-#'   databaseStart = "minimal-example",
-#'   variables = "inst/extdata/minimal-example/variables.csv",
-#'   variable_details = "inst/extdata/minimal-example/variable_details.csv",
-#'   n = 1000,
-#'   seed = 123
-#' )
-#'
-#' # With data frames instead of file paths
-#' variables <- read.csv("inst/extdata/minimal-example/variables.csv",
-#'                       stringsAsFactors = FALSE)
-#' variable_details <- read.csv("inst/extdata/minimal-example/variable_details.csv",
-#'                               stringsAsFactors = FALSE)
-#'
-#' mock_data <- create_mock_data(
-#'   databaseStart = "minimal-example",
-#'   variables = variables,
-#'   variable_details = variable_details,
-#'   n = 1000,
-#'   seed = 123
-#' )
-#'
 #' # Fallback mode (uniform distributions, no variable_details)
 #' mock_data <- create_mock_data(
 #'   databaseStart = "minimal-example",
@@ -212,10 +203,6 @@
 #'   variable_details = NULL,
 #'   n = 500
 #' )
-#'
-#' # View structure
-#' str(mock_data)
-#' head(mock_data)
 #' }
 #'
 #' @family generators

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -168,7 +168,7 @@
 #'
 #' **Fallback mode**: If variable_details = NULL, uses simple default generators
 #' for enabled variables (two-category categorical values, continuous values from
-#' [0, 100], and dates from 2000-01-01 to 2025-12-31).
+#' `[0, 100]`, and dates from 2000-01-01 to 2025-12-31).
 #'
 #' **Variable types supported**:
 #' \itemize{

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -233,26 +233,12 @@ create_mock_data <- function(databaseStart,
 
   # ========== LOAD METADATA ==========
 
-  # Load variables from file path if needed
-  if (is.character(variables) && length(variables) == 1) {
-    if (!file.exists(variables)) {
-      stop("Configuration file does not exist: ", variables)
-    }
-    if (verbose) message("Reading variables file: ", variables)
-    variables <- read.csv(variables, stringsAsFactors = FALSE, check.names = FALSE)
-  }
-
-  # Load variable_details from file path if needed
-  if (!is.null(variable_details)) {
-    if (is.character(variable_details) && length(variable_details) == 1) {
-      if (!file.exists(variable_details)) {
-        stop("Details file does not exist: ", variable_details)
-      }
-      if (verbose) message("Reading variable_details file: ", variable_details)
-      variable_details <- read.csv(variable_details, stringsAsFactors = FALSE, check.names = FALSE)
-    }
-  } else {
-    if (verbose) message("No details file provided - using simple fallback generation")
+  variables <- .load_metadata_df(variables, "variables", verbose = verbose)
+  variable_details <- .load_metadata_df(
+    variable_details, "variable_details", verbose = verbose
+  )
+  if (is.null(variable_details) && verbose) {
+    message("No details file provided - using simple fallback generation")
   }
 
   variables <- .migrate_garbage_aliases(variables)

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -363,6 +363,7 @@ create_mock_data <- function(databaseStart,
         stop(msg, call. = FALSE)
       }
       warning(msg)
+      skipped_vars <- c(skipped_vars, var_name)
       next
     }
 
@@ -415,6 +416,12 @@ create_mock_data <- function(databaseStart,
       for (col_name in names(var_data)) {
         df_mock[[col_name]] <- var_data[[col_name]]
       }
+    } else if (is.null(var_data) && !var_name %in% names(df_mock)) {
+      # Generators can return NULL without erroring (e.g. survival-date
+      # preconditions not met, no valid categories). Track those so the
+      # end-of-run summary reflects every absent column. The names(df_mock)
+      # check keeps legitimate already-exists skips out of the summary.
+      skipped_vars <- c(skipped_vars, var_name)
     }
   }
 
@@ -426,7 +433,9 @@ create_mock_data <- function(databaseStart,
     message("  Variables: ", ncol(df_mock))
   }
 
-  if (!validate && length(skipped_vars) > 0) {
+  # Fires in both modes: strict mode can also drop columns when a generator
+  # returns NULL without erroring.
+  if (length(skipped_vars) > 0) {
     skipped_vars <- unique(skipped_vars)
     message("Skipped variables during mock data generation: ",
             paste(skipped_vars, collapse = ", "))

--- a/R/create_wide_survival_data.R
+++ b/R/create_wide_survival_data.R
@@ -183,6 +183,13 @@ create_wide_survival_data <- function(var_entry_date,
   if (missing(databaseStart) || is.null(databaseStart)) {
     stop("databaseStart parameter is required")
   }
+  # Load metadata from file paths if needed
+  if (!missing(variables)) {
+    variables <- .load_metadata_df(variables, "variables")
+  }
+  if (!missing(variable_details)) {
+    variable_details <- .load_metadata_df(variable_details, "variable_details")
+  }
   if (missing(variables) || !is.data.frame(variables)) {
     stop("variables must be a data frame (full metadata, not pre-filtered)")
   }

--- a/R/create_wide_survival_data.R
+++ b/R/create_wide_survival_data.R
@@ -193,10 +193,10 @@ create_wide_survival_data <- function(var_entry_date,
     variable_details <- .load_metadata_df(variable_details, "variable_details")
   }
   if (missing(variables) || !is.data.frame(variables)) {
-    stop("variables must be a data frame (full metadata, not pre-filtered)")
+    stop("variables must be a data frame or a CSV file path (full metadata, not pre-filtered)")
   }
   if (missing(variable_details) || !is.data.frame(variable_details)) {
-    stop("variable_details must be a data frame (full metadata, not pre-filtered)")
+    stop("variable_details must be a data frame or a CSV file path (full metadata, not pre-filtered)")
   }
   if (missing(n) || is.null(n) || !is.numeric(n) || n <= 0) {
     stop("n must be a positive integer")

--- a/R/create_wide_survival_data.R
+++ b/R/create_wide_survival_data.R
@@ -16,10 +16,12 @@
 #'   censoring date. Set to NULL to skip.
 #' @param databaseStart character. Required. Database identifier for filtering metadata
 #'   (used with databaseStart column in variable_details).
-#' @param variables data.frame. Required. Full variables metadata (not pre-filtered).
+#' @param variables data.frame or character. Full variables metadata (not pre-filtered).
 #'   Must contain columns: variable, variableType.
-#' @param variable_details data.frame. Required. Full variable details metadata
+#'   Can also be a file path (character) to variables.csv.
+#' @param variable_details data.frame or character. Full variable details metadata
 #'   (not pre-filtered). Will be filtered internally using databaseStart column.
+#'   Can also be a file path (character) to variable_details.csv.
 #' @param df_mock data.frame. Optional. The current mock data to check if variables
 #'   already exist and to use as anchor_date source. Default: NULL.
 #' @param n integer. Required. Number of observations to generate.

--- a/R/load_metadata.R
+++ b/R/load_metadata.R
@@ -22,7 +22,10 @@
     return(x)
   }
   if (is.character(x) && length(x) == 1) {
-    if (!file.exists(x) || dir.exists(x)) {
+    if (dir.exists(x)) {
+      stop(what, " path is a directory, not a CSV file: ", x, call. = FALSE)
+    }
+    if (!file.exists(x)) {
       stop(what, " file does not exist: ", x, call. = FALSE)
     }
     if (verbose) message("Reading ", what, " file: ", x)

--- a/R/load_metadata.R
+++ b/R/load_metadata.R
@@ -1,0 +1,28 @@
+#' Load metadata from a file path or pass a data frame through
+#'
+#' Internal helper shared by create_mock_data() and the create_* generators.
+#' Accepts a data frame (returned unchanged), NULL (returned unchanged, for
+#' optional variable_details), or a single CSV file path (read with
+#' check.names = FALSE to preserve recodeflow column names).
+#'
+#' @param x data.frame, NULL, or length-1 character file path.
+#' @param what Character. Argument name used in messages ("variables",
+#'   "variable_details").
+#' @param verbose Logical. Emit a message when reading from file.
+#'
+#' @return data.frame or NULL.
+#' @noRd
+.load_metadata_df <- function(x, what, verbose = FALSE) {
+  if (is.null(x) || is.data.frame(x)) {
+    return(x)
+  }
+  if (is.character(x) && length(x) == 1) {
+    if (!file.exists(x)) {
+      stop(what, " file does not exist: ", x, call. = FALSE)
+    }
+    if (verbose) message("Reading ", what, " file: ", x)
+    return(read.csv(x, stringsAsFactors = FALSE, check.names = FALSE))
+  }
+  stop("`", what, "` must be a data frame or a single CSV file path",
+       call. = FALSE)
+}

--- a/R/load_metadata.R
+++ b/R/load_metadata.R
@@ -3,12 +3,14 @@
 #' Internal helper shared by create_mock_data() and the create_* generators.
 #' Accepts a data frame (returned unchanged), NULL (returned unchanged, for
 #' optional variable_details), or a single CSV file path (read with
-#' check.names = FALSE to preserve recodeflow column names).
+#' check.names = FALSE to preserve recodeflow column names). A path that
+#' points to a directory, or one that does not exist, is an error.
 #'
 #' Note: the v0.4 pipeline has its own reader, .read_recodeflow_table()
-#' (R/mock_spec_recodeflow.R), which additionally maps "" and "NA" cells to NA
-#' via na.strings. This helper keeps read.csv defaults to preserve the legacy
-#' create_* generators' behaviour. Keep the two in mind if consolidating.
+#' (R/mock_spec_recodeflow.R), which additionally maps empty-string cells
+#' ("") to NA via na.strings (read.csv already treats "NA" as missing by
+#' default). This helper keeps read.csv defaults to preserve the legacy
+#' create_* generators' behaviour.
 #'
 #' @param x data.frame, NULL, or length-1 character file path.
 #' @param what Character. Argument name used in messages ("variables",

--- a/R/load_metadata.R
+++ b/R/load_metadata.R
@@ -5,6 +5,11 @@
 #' optional variable_details), or a single CSV file path (read with
 #' check.names = FALSE to preserve recodeflow column names).
 #'
+#' Note: the v0.4 pipeline has its own reader, .read_recodeflow_table()
+#' (R/mock_spec_recodeflow.R), which additionally maps "" and "NA" cells to NA
+#' via na.strings. This helper keeps read.csv defaults to preserve the legacy
+#' create_* generators' behaviour. Keep the two in mind if consolidating.
+#'
 #' @param x data.frame, NULL, or length-1 character file path.
 #' @param what Character. Argument name used in messages ("variables",
 #'   "variable_details").
@@ -17,7 +22,7 @@
     return(x)
   }
   if (is.character(x) && length(x) == 1) {
-    if (!file.exists(x)) {
+    if (!file.exists(x) || dir.exists(x)) {
       stop(what, " file does not exist: ", x, call. = FALSE)
     }
     if (verbose) message("Reading ", what, " file: ", x)

--- a/R/mock_spec_recodeflow.R
+++ b/R/mock_spec_recodeflow.R
@@ -6,6 +6,8 @@
 # ==============================================================================
 
 #' @noRd
+# See also .load_metadata_df() (R/load_metadata.R): the legacy loader with
+# read.csv default na.strings. The two differ intentionally.
 .read_recodeflow_table <- function(x, label) {
   if (is.data.frame(x)) {
     return(x)

--- a/R/mockdata_helpers.R
+++ b/R/mockdata_helpers.R
@@ -920,13 +920,14 @@ apply_rtype_defaults <- function(details) {
     # Apply defaults based on type
     type_lower <- tolower(details[[type_col]])
 
-    details$rType <- dplyr::case_when(
-      type_lower %in% c("cont", "continuous") ~ "double",    # Continuous → double (default)
-      type_lower %in% c("cat", "categorical") ~ "factor",    # Categorical → factor (default)
-      type_lower == "date" ~ "date",                         # Date -> date (default)
-      type_lower == "logical" ~ "logical",                   # Logical → logical
-      TRUE ~ "character"                                     # Fallback
-    )
+    # Fallback first, then overwrite recognized types. %in% is used for every
+    # comparison (including single values) because it maps NA to FALSE, which
+    # `==` does not — NA in a logical subscript assignment is an error.
+    details$rType <- "character"
+    details$rType[type_lower %in% c("cont", "continuous")] <- "double"
+    details$rType[type_lower %in% c("cat", "categorical")] <- "factor"
+    details$rType[type_lower %in% "date"] <- "date"
+    details$rType[type_lower %in% "logical"] <- "logical"
   } else {
     # No type column found - default to character
     details$rType <- "character"

--- a/R/mockdata_helpers.R
+++ b/R/mockdata_helpers.R
@@ -920,9 +920,10 @@ apply_rtype_defaults <- function(details) {
     # Apply defaults based on type
     type_lower <- tolower(details[[type_col]])
 
-    # Fallback first, then overwrite recognized types. %in% is used for every
-    # comparison (including single values) because it maps NA to FALSE, which
-    # `==` does not — NA in a logical subscript assignment is an error.
+    # Fallback first, then overwrite recognized types. The four %in% sets are
+    # disjoint, so assignment order does not matter. %in% maps NA to FALSE,
+    # sending NA types explicitly to the "character" fallback rather than
+    # relying on R's silent skipping of NA subscripts in scalar assignments.
     details$rType <- "character"
     details$rType[type_lower %in% c("cont", "continuous")] <- "double"
     details$rType[type_lower %in% c("cat", "categorical")] <- "factor"

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ MockData uses a three-file architecture that separates project data dictionaries
    - Transformation rules (recStart, recEnd, copy, catLabel)
    - Example: `uvariable, recStart, catLabel`
 
-3. **MockData-specific parameters** (`mock_config.csv`, optional)
+3. **MockData-specific parameters** (`mock_data_config.csv`, optional)
 
    - Proportions of variable categories
    - Event occurrence probabilities (`event_occurs`)

--- a/tests/testthat/test-critical-regressions.R
+++ b/tests/testthat/test-critical-regressions.R
@@ -535,9 +535,49 @@ test_that("generators warn when duplicate variables rows match", {
       var = "age", databaseStart = "study",
       variables = variables, variable_details = details, n = 10, seed = 1
     ),
-    "Multiple variables rows"
+    "Multiple rows found"
   )
   expect_s3_class(result, "data.frame")
+
+  variables_cat <- data.frame(
+    variable = c("smoke", "smoke"), variableType = "Categorical",
+    rType = "factor", stringsAsFactors = FALSE
+  )
+  details_cat <- data.frame(
+    variable = "smoke", recStart = c("1", "2"), recEnd = c("1", "2"),
+    proportion = c(0.5, 0.5), databaseStart = "study",
+    stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    result_cat <- create_cat_var(
+      var = "smoke", databaseStart = "study",
+      variables = variables_cat, variable_details = details_cat,
+      n = 10, seed = 1
+    ),
+    "Multiple rows found"
+  )
+  expect_s3_class(result_cat, "data.frame")
+
+  variables_date <- data.frame(
+    variable = c("entry_date", "entry_date"), variableType = "Date",
+    rType = "date", stringsAsFactors = FALSE
+  )
+  details_date <- data.frame(
+    variable = "entry_date", recStart = "[2020-01-01,2024-12-31]",
+    recEnd = "copy", proportion = 1, databaseStart = "study",
+    stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    result_date <- create_date_var(
+      var = "entry_date", databaseStart = "study",
+      variables = variables_date, variable_details = details_date,
+      n = 10, seed = 1
+    ),
+    "Multiple rows found"
+  )
+  expect_s3_class(result_date, "data.frame")
 })
 
 test_that("create_mock_data validate = FALSE path still returns a data frame", {
@@ -559,4 +599,6 @@ test_that("create_mock_data validate = FALSE path still returns a data frame", {
     variable_details = details, n = 10, seed = 1, validate = FALSE
   )
   expect_s3_class(result, "data.frame")
+  expect_true("age" %in% names(result))
+  expect_equal(nrow(result), 10)
 })

--- a/tests/testthat/test-critical-regressions.R
+++ b/tests/testthat/test-critical-regressions.R
@@ -486,3 +486,77 @@ test_that("create_mock_data summarizes skipped variables when validate is FALSE"
   expect_equal(nrow(result), 5)
   expect_equal(ncol(result), 0)
 })
+
+test_that("generators stop when the variable is missing from variables metadata", {
+  variables <- data.frame(
+    variable = "age", variableType = "Continuous", rType = "integer",
+    stringsAsFactors = FALSE
+  )
+  details <- data.frame(
+    variable = "age", recStart = "[18,85]", recEnd = "copy",
+    proportion = 1, databaseStart = "study", stringsAsFactors = FALSE
+  )
+
+  expect_error(
+    create_con_var(
+      var = "no_such_var", databaseStart = "study",
+      variables = variables, variable_details = details, n = 10
+    ),
+    "not found in variables metadata"
+  )
+  expect_error(
+    create_cat_var(
+      var = "no_such_var", databaseStart = "study",
+      variables = variables, variable_details = details, n = 10
+    ),
+    "not found in variables metadata"
+  )
+  expect_error(
+    create_date_var(
+      var = "no_such_var", databaseStart = "study",
+      variables = variables, variable_details = details, n = 10
+    ),
+    "not found in variables metadata"
+  )
+})
+
+test_that("generators warn when duplicate variables rows match", {
+  variables <- data.frame(
+    variable = c("age", "age"), variableType = "Continuous",
+    rType = "integer", stringsAsFactors = FALSE
+  )
+  details <- data.frame(
+    variable = "age", recStart = "[18,85]", recEnd = "copy",
+    proportion = 1, databaseStart = "study", stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    result <- create_con_var(
+      var = "age", databaseStart = "study",
+      variables = variables, variable_details = details, n = 10, seed = 1
+    ),
+    "Multiple variables rows"
+  )
+  expect_s3_class(result, "data.frame")
+})
+
+test_that("create_mock_data validate = FALSE path still returns a data frame", {
+  # Smoke test that the orchestrator's tryCatch + validate = FALSE contract
+  # survives the generator changes. (Missing-from-variables cannot be
+  # triggered through the orchestrator itself, since it derives var names
+  # from the variables data frame — this guards the happy path under the
+  # permissive flag.)
+  variables <- data.frame(
+    variable = "age", variableType = "Continuous", rType = "integer",
+    role = "enabled", stringsAsFactors = FALSE
+  )
+  details <- data.frame(
+    variable = "age", recStart = "[18,85]", recEnd = "copy",
+    proportion = 1, databaseStart = "study", stringsAsFactors = FALSE
+  )
+  result <- create_mock_data(
+    databaseStart = "study", variables = variables,
+    variable_details = details, n = 10, seed = 1, validate = FALSE
+  )
+  expect_s3_class(result, "data.frame")
+})

--- a/tests/testthat/test-critical-regressions.R
+++ b/tests/testthat/test-critical-regressions.R
@@ -580,6 +580,84 @@ test_that("generators warn when duplicate variables rows match", {
   expect_s3_class(result_date, "data.frame")
 })
 
+test_that("create_mock_data reports skipped variables when a generator returns NULL under validate = TRUE", {
+  # A survival-style date variable (followup_min/max/event_prop set) requires
+  # an anchor_date column in df_mock. create_mock_data never supplies one, so
+  # create_date_var warns and returns NULL without erroring — the column is
+  # silently absent. The end-of-run summary must report it even in strict mode.
+  # (distribution = "gompertz" keeps the v0.4 pipeline from claiming the run,
+  # so this exercises the legacy dispatch path.)
+  variables <- data.frame(
+    variable = c("age", "event_date"),
+    variableType = c("Continuous", "Date"),
+    rType = c("integer", "date"),
+    role = c("enabled", "enabled"),
+    distribution = c(NA, "gompertz"),
+    followup_min = c(NA, 365),
+    followup_max = c(NA, 3650),
+    event_prop = c(NA, 0.5),
+    stringsAsFactors = FALSE
+  )
+  details <- data.frame(
+    variable = c("age", "event_date"),
+    recStart = c("[18,85]", "[2001-01-01,2005-12-31]"),
+    recEnd = c("copy", "copy"),
+    proportion = c(1, 1),
+    stringsAsFactors = FALSE
+  )
+
+  expect_message(
+    expect_warning(
+      result <- create_mock_data(
+        databaseStart = "study",
+        variables = variables,
+        variable_details = details,
+        n = 5,
+        seed = 1,
+        validate = TRUE
+      ),
+      "anchor_date"
+    ),
+    "Skipped variables.*event_date"
+  )
+
+  expect_s3_class(result, "data.frame")
+  expect_true("age" %in% names(result))
+  expect_false("event_date" %in% names(result))
+})
+
+test_that("create_mock_data lists missing-rType variables in the skipped summary when validate = FALSE", {
+  variables <- data.frame(
+    variable = c("age", "no_rtype_var"),
+    variableType = c("Continuous", "Continuous"),
+    rType = c("integer", NA),
+    role = c("enabled", "enabled"),
+    stringsAsFactors = FALSE
+  )
+  details <- data.frame(
+    variable = "age", recStart = "[18,85]", recEnd = "copy",
+    proportion = 1, stringsAsFactors = FALSE
+  )
+
+  expect_message(
+    expect_warning(
+      result <- create_mock_data(
+        databaseStart = "study",
+        variables = variables,
+        variable_details = details,
+        n = 5,
+        seed = 1,
+        validate = FALSE
+      ),
+      "missing rType"
+    ),
+    "Skipped variables.*no_rtype_var"
+  )
+
+  expect_true("age" %in% names(result))
+  expect_false("no_rtype_var" %in% names(result))
+})
+
 test_that("create_mock_data validate = FALSE path still returns a data frame", {
   # Smoke test that the orchestrator's tryCatch + validate = FALSE contract
   # survives the generator changes. (Missing-from-variables cannot be

--- a/tests/testthat/test-load-metadata.R
+++ b/tests/testthat/test-load-metadata.R
@@ -1,0 +1,37 @@
+# Tests for .load_metadata_df() — shared metadata-loading helper
+
+test_that(".load_metadata_df passes data frames and NULL through unchanged", {
+  df <- data.frame(variable = "age", stringsAsFactors = FALSE)
+  expect_identical(MockData:::.load_metadata_df(df, "variables"), df)
+  expect_null(MockData:::.load_metadata_df(NULL, "variable_details"))
+})
+
+test_that(".load_metadata_df reads a CSV path with check.names = FALSE", {
+  path <- tempfile(fileext = ".csv")
+  on.exit(unlink(path))
+  write.csv(
+    data.frame(`odd name` = 1:2, check.names = FALSE),
+    path, row.names = FALSE
+  )
+  result <- MockData:::.load_metadata_df(path, "variables")
+  expect_s3_class(result, "data.frame")
+  expect_named(result, "odd name")
+})
+
+test_that(".load_metadata_df errors clearly on a missing file", {
+  expect_error(
+    MockData:::.load_metadata_df("no/such/file.csv", "variables"),
+    "variables file does not exist"
+  )
+})
+
+test_that(".load_metadata_df rejects non-path, non-data-frame input", {
+  expect_error(
+    MockData:::.load_metadata_df(c("a.csv", "b.csv"), "variables"),
+    "must be a data frame or a single CSV file path"
+  )
+  expect_error(
+    MockData:::.load_metadata_df(42, "variables"),
+    "must be a data frame or a single CSV file path"
+  )
+})

--- a/tests/testthat/test-load-metadata.R
+++ b/tests/testthat/test-load-metadata.R
@@ -55,6 +55,6 @@ test_that(".load_metadata_df rejects a directory path", {
 
   expect_error(
     MockData:::.load_metadata_df(dir_path, "variables"),
-    "variables file does not exist"
+    "is a directory, not a CSV file"
   )
 })

--- a/tests/testthat/test-load-metadata.R
+++ b/tests/testthat/test-load-metadata.R
@@ -35,3 +35,26 @@ test_that(".load_metadata_df rejects non-path, non-data-frame input", {
     "must be a data frame or a single CSV file path"
   )
 })
+
+test_that(".load_metadata_df emits the reading message when verbose", {
+  path <- tempfile(fileext = ".csv")
+  on.exit(unlink(path))
+  write.csv(data.frame(variable = "age"), path, row.names = FALSE)
+
+  expect_message(
+    MockData:::.load_metadata_df(path, "variables", verbose = TRUE),
+    "Reading variables file: "
+  )
+  expect_silent(MockData:::.load_metadata_df(path, "variables"))
+})
+
+test_that(".load_metadata_df rejects a directory path", {
+  dir_path <- tempfile()
+  dir.create(dir_path)
+  on.exit(unlink(dir_path, recursive = TRUE))
+
+  expect_error(
+    MockData:::.load_metadata_df(dir_path, "variables"),
+    "variables file does not exist"
+  )
+})

--- a/tests/testthat/test-recodeflow-mock-spec.R
+++ b/tests/testthat/test-recodeflow-mock-spec.R
@@ -1,5 +1,7 @@
 minimal_example_path <- function(...) {
-  file.path("..", "..", "inst", "extdata", "minimal-example", ...)
+  path <- system.file("extdata", "minimal-example", ..., package = "MockData")
+  skip_if(path == "", "minimal-example fixtures not found")
+  path
 }
 
 test_that("mock_spec_from_recodeflow converts minimal metadata", {

--- a/tests/testthat/test-rtype-coercion.R
+++ b/tests/testthat/test-rtype-coercion.R
@@ -258,6 +258,53 @@ test_that("create_cat_var defaults to character when rType not specified", {
 })
 
 # ==============================================================================
+# create_mock_data() DISPATCH: rTypes not covered elsewhere through the
+# orchestrator (characterization tests for the legacy dispatch path)
+# ==============================================================================
+# These fixtures omit databaseStart from `variables` while including it in
+# `variable_details`, which routes create_mock_data() to the legacy create_*
+# dispatch (the v0.4 pipeline declines detail-level databaseStart filtering).
+
+test_that("create_mock_data dispatches rType = 'numeric' to the continuous generator", {
+  variables <- data.frame(
+    variable = "bmi", variableType = "Continuous", rType = "numeric",
+    role = "enabled", stringsAsFactors = FALSE
+  )
+  variable_details <- data.frame(
+    variable = "bmi", recStart = "[15,40]", recEnd = "copy",
+    proportion = 1, databaseStart = "study", stringsAsFactors = FALSE
+  )
+  result <- create_mock_data(
+    databaseStart = "study", variables = variables,
+    variable_details = variable_details, n = 25, seed = 42
+  )
+  expect_true(is.numeric(result$bmi))
+  expect_equal(nrow(result), 25)
+})
+
+test_that("create_mock_data dispatches rType = 'logical' to the categorical generator", {
+  variables <- data.frame(
+    variable = "eligible", variableType = "Categorical", rType = "logical",
+    role = "enabled", stringsAsFactors = FALSE
+  )
+  variable_details <- data.frame(
+    variable = c("eligible", "eligible"),
+    recStart = c("TRUE", "FALSE"),
+    recEnd = c("TRUE", "FALSE"),
+    catLabel = c("Eligible", "Not eligible"),
+    proportion = c(0.5, 0.5),
+    databaseStart = c("study", "study"),
+    stringsAsFactors = FALSE
+  )
+  result <- create_mock_data(
+    databaseStart = "study", variables = variables,
+    variable_details = variable_details, n = 25, seed = 42
+  )
+  expect_true(is.logical(result$eligible))
+  expect_equal(nrow(result), 25)
+})
+
+# ==============================================================================
 # HELPER: apply_rtype_defaults()
 # ==============================================================================
 

--- a/tests/testthat/test-rtype-coercion.R
+++ b/tests/testthat/test-rtype-coercion.R
@@ -278,7 +278,7 @@ test_that("create_mock_data dispatches rType = 'numeric' to the continuous gener
     databaseStart = "study", variables = variables,
     variable_details = variable_details, n = 25, seed = 42
   )
-  expect_true(is.numeric(result$bmi))
+  expect_type(result$bmi, "double")
   expect_equal(nrow(result), 25)
 })
 

--- a/tests/testthat/test-rtype-coercion.R
+++ b/tests/testthat/test-rtype-coercion.R
@@ -317,3 +317,15 @@ test_that("apply_rtype_defaults validates rType values", {
     "Invalid rType values found"
   )
 })
+
+test_that("rType defaults handle NA and unknown variableType values", {
+  details <- data.frame(
+    variable = c("a", "b", "c", "d"),
+    variableType = c("Continuous", NA, "weird-type", "Date"),
+    stringsAsFactors = FALSE
+  )
+
+  result <- apply_rtype_defaults(details)
+
+  expect_equal(result$rType, c("double", "character", "character", "date"))
+})

--- a/tests/testthat/test-rtype-coercion.R
+++ b/tests/testthat/test-rtype-coercion.R
@@ -318,14 +318,14 @@ test_that("apply_rtype_defaults validates rType values", {
   )
 })
 
-test_that("rType defaults handle NA and unknown variableType values", {
+test_that("apply_rtype_defaults handles NA, unknown, and logical variableType values", {
   details <- data.frame(
-    variable = c("a", "b", "c", "d"),
-    variableType = c("Continuous", NA, "weird-type", "Date"),
+    variable = c("a", "b", "c", "d", "e"),
+    variableType = c("Continuous", NA, "weird-type", "Date", "logical"),
     stringsAsFactors = FALSE
   )
 
   result <- apply_rtype_defaults(details)
 
-  expect_equal(result$rType, c("double", "character", "character", "date"))
+  expect_equal(result$rType, c("double", "character", "character", "date", "logical"))
 })

--- a/tests/testthat/test-survival-data.R
+++ b/tests/testthat/test-survival-data.R
@@ -306,3 +306,64 @@ test_that("create_wide_survival_data validates required parameters", {
     "databaseStart parameter is required"
   )
 })
+
+test_that("create_wide_survival_data accepts CSV file paths and propagates generator errors", {
+  # Same fixture shape as the basic entry + event test above
+  variables <- data.frame(
+    variable = c("interview_date", "primary_event_date"),
+    variableType = c("Date", "Date"),
+    role = c("enabled", "enabled"),
+    followup_min = c(NA, 365),
+    followup_max = c(NA, 3650),
+    event_prop = c(NA, 1.0),
+    stringsAsFactors = FALSE
+  )
+
+  variable_details <- data.frame(
+    variable = c("interview_date", "interview_date"),
+    recStart = c("[2001-01-01,2005-12-31]", NA),
+    recEnd = c("copy", "NA::b"),
+    stringsAsFactors = FALSE
+  )
+
+  # 1. CSV-path input: metadata supplied as file paths, not data frames
+  variables_path <- tempfile(fileext = ".csv")
+  details_path <- tempfile(fileext = ".csv")
+  write.csv(variables, variables_path, row.names = FALSE)
+  write.csv(variable_details, details_path, row.names = FALSE)
+
+  result <- create_wide_survival_data(
+    var_entry_date = "interview_date",
+    var_event_date = "primary_event_date",
+    var_death_date = NULL,
+    var_ltfu = NULL,
+    var_admin_censor = NULL,
+    databaseStart = "test",
+    variables = variables_path,
+    variable_details = details_path,
+    n = 100,
+    seed = 123
+  )
+
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 100)
+  expect_true("interview_date" %in% names(result))
+  expect_true("primary_event_date" %in% names(result))
+
+  # 2. Error propagation: unknown entry variable surfaces the generator error
+  expect_error(
+    create_wide_survival_data(
+      var_entry_date = "typo_var",
+      var_event_date = "primary_event_date",
+      var_death_date = NULL,
+      var_ltfu = NULL,
+      var_admin_censor = NULL,
+      databaseStart = "test",
+      variables = variables,
+      variable_details = variable_details,
+      n = 100,
+      seed = 123
+    ),
+    "not found in variables metadata"
+  )
+})


### PR DESCRIPTION
## Summary

Implements the five recommendations from the 2026-06-09 code-quality review, plus a fix-it-when-found tidy round. All changes target the v0.4 RC (`dev`).

- **README**: fix config-file naming drift (`mock_config.csv` → `mock_data_config.csv`)
- **Dependencies**: drop `dplyr` from Imports (single `case_when` replaced with base R; moved to Suggests for vignettes)
- **DRY**: new internal `.load_metadata_df()` replaces the copy-pasted load-CSV-if-path preamble at 5 call sites; rejects directory paths with a clear error
- **DRY**: the seven-arm rType dispatch `switch` in `create_mock_data()`'s legacy path collapsed to a `generator_map` lookup (−65/+16 lines); supported-types error message derives from the map
- **Breaking (documented in NEWS)**: `create_cat_var()` / `create_con_var()` / `create_date_var()` now stop with `Variable '<name>' not found in variables metadata` instead of warning and returning `NULL`; duplicate metadata rows warn before taking the first row; all generator warnings use `call. = FALSE`. `create_mock_data(validate = FALSE)` retains warn-and-skip on the legacy path.
- **Docs**: self-contained roxygen examples in 4 files converted out of `\dontrun` so `R CMD check` exercises them; categorical example uses the packaged minimal-example smoking rows verbatim
- **Pre-existing check failures fixed**: `test-recodeflow-mock-spec.R` now uses `system.file()` instead of `../../inst/` relative paths (was the only check ERROR); literal `[0, 100]` in roxygen escaped to stop Rd link warning (was the only check WARNING)

## Test plan

- [x] Full suite green: `[ FAIL 0 | WARN 34 | SKIP 10 | PASS 627 ]` (baseline before branch: 600 passing; +27 new expectations)
- [x] Behaviour preservation: seeded output (n=200, seed=777, minimal-example) is `identical()` between `dev` base and branch HEAD
- [x] `devtools::run_examples()` clean (warnings are expected diagnostics, explained inline)
- [x] Every task passed independent spec-compliance and code-quality reviews during development
- [x] `R CMD check` after final tidy commits: 0 errors, 0 warnings, 5 pre-existing notes

## Breaking-change note for v0.3 users

See `NEWS.md` → 0.4.0 → Breaking changes: missing-variable errors (direct generator calls and `create_wide_survival_data()`), duplicate-row warnings (legacy path; the v0.4 `mock_spec` path already errors on duplicate names), and renamed metadata-file error messages.