### PR TITLE
v0.4.x hardening: edge-case contract, entry validation, native exponential

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,8 @@
 ^renv$
 ^renv\.lock$
 ^.*\.Rproj$
+^.*\.Rcheck$
+^.*\.tar\.gz$
 ^\.Rproj\.user$
 ^\.DS_Store$
 ^\.git$
@@ -23,7 +25,12 @@
 ^PR_DESCRIPTION_ADDENDUM\.md$
 ^REVIEWER_QUICKSTART\.md$
 ^LOCAL_TESTING_GUIDE\.md$
+^cran-comments\.md$
 ^docs$
 ^_pkgdown\.yml$
+^pkgdown$
 ^development$
 ^\.claude$
+^vignettes/\.quarto$
+^vignettes/.*_files$
+^vignettes/.*\.html$

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docs/
 # Quarto/HTML output
 Generate_mock_data.html
 Generate_mock_data_files/
+vignettes/.quarto/
+vignettes/*_files/
+vignettes/*.html

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# MockData (development version)
+
+- `create_mock_data()` now accepts `n = 0`, returning a zero-row data frame
+  with the full generated schema (useful for schema tests), and rejects
+  fractional, negative, and `NA` values of `n` with a clear message. The
+  validation now matches `generate_mock_data_native()`.
+
 # MockData 0.4.0 (2026-06-10)
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
   validation now matches `generate_mock_data_native()`.
 - Calling `create_mock_data()` without `databaseStart` now fails upfront with
   a message naming the argument, instead of a raw missing-argument error.
+- The native backend now supports `distribution = "exponential"` (parity with
+  the legacy generator), removing a forced legacy-fallback for exponential
+  metadata. Unlike the legacy `rexp()`, native exponential values are
+  truncated to the declared `range`, consistent with the native normal
+  distribution.
 
 # MockData 0.4.0 (2026-06-10)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,8 @@
   the legacy generator), removing a forced legacy-fallback for exponential
   metadata. Unlike the legacy `rexp()`, native exponential values are
   truncated to the declared `range`, consistent with the native normal
-  distribution.
+  distribution. Exponential specs also generate via the simstudy hybrid path,
+  which routes non-uniform continuous variables to the native generator.
 
 # MockData 0.4.0 (2026-06-10)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,16 +2,23 @@
 
 - `create_mock_data()` now accepts `n = 0`, returning a zero-row data frame
   with the full generated schema (useful for schema tests), and rejects
-  fractional, negative, and `NA` values of `n` with a clear message. The
-  validation now matches `generate_mock_data_native()`.
+  fractional, negative, `NA`, and non-finite values of `n` with a clear
+  message. The validation now matches `generate_mock_data_native()`.
 - Calling `create_mock_data()` without `databaseStart` now fails upfront with
   a message naming the argument, instead of a raw missing-argument error.
 - The native backend now supports `distribution = "exponential"` (parity with
   the legacy generator), removing a forced legacy-fallback for exponential
-  metadata. Unlike the legacy `rexp()`, native exponential values are
-  truncated to the declared `range`, consistent with the native normal
-  distribution. Exponential specs also generate via the simstudy hybrid path,
-  which routes non-uniform continuous variables to the native generator.
+  metadata. When the optional simstudy backend is selected, exponential
+  variables are routed to the native generator (like all non-uniform
+  continuous distributions); the simstudy package itself is not involved in
+  their generation. Native exponential values are truncated to the declared
+  `range` by inverse-CDF sampling, rather than clipped at the range maximum
+  (with a point mass at the boundary) as the legacy `rexp()` path does.
+- With `validate = TRUE` (the default), invalid distribution parameters in
+  metadata — e.g. `distribution = "exponential"` without a positive `rate` —
+  now stop generation with a message naming the variable and how to fix it,
+  instead of warning and substituting a uniform draw. The legacy
+  warn-and-substitute behaviour remains available via `validate = FALSE`.
 
 # MockData 0.4.0 (2026-06-10)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
   with the full generated schema (useful for schema tests), and rejects
   fractional, negative, and `NA` values of `n` with a clear message. The
   validation now matches `generate_mock_data_native()`.
+- Calling `create_mock_data()` without `databaseStart` now fails upfront with
+  a message naming the argument, instead of a raw missing-argument error.
 
 # MockData 0.4.0 (2026-06-10)
 

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -59,11 +59,24 @@
     return(NULL)
   }
 
-  spec <- mock_spec_from_recodeflow(
-    variables = variables,
-    variable_details = variable_details,
-    databaseStart = .create_mock_data_v04_database_filter(variables, databaseStart),
-    role = "enabled"
+  spec <- tryCatch(
+    mock_spec_from_recodeflow(
+      variables = variables,
+      variable_details = variable_details,
+      databaseStart = .create_mock_data_v04_database_filter(variables, databaseStart),
+      role = "enabled"
+    ),
+    error = function(e) {
+      stop(
+        conditionMessage(e), "\n",
+        "Metadata validation failed while building the v0.4 specification. ",
+        "Fix the metadata (for exponential variables, supply a positive 'rate'), ",
+        "or call create_mock_data() with validate = FALSE to use the legacy ",
+        "generator, which warns and substitutes a uniform draw for invalid ",
+        "distribution parameters.",
+        call. = FALSE
+      )
+    }
   )
 
   unsupported <- .create_mock_data_v04_unsupported_variables(spec)
@@ -120,6 +133,8 @@
 #'   Can also be a file path (character) to variable_details.csv.
 #'   If NULL, uses simple fallback generation.
 #' @param n Integer. Number of observations to generate (default 1000).
+#'   `n = 0` is supported and returns a zero-row data frame with the full
+#'   generated schema.
 #' @param seed Integer. Optional random seed for reproducibility.
 #' @param validate Logical. Whether to use strict generation checks (default
 #'   TRUE). When TRUE, unsupported variable types and generator errors stop
@@ -245,7 +260,7 @@ create_mock_data <- function(databaseStart,
 
   # ========== VALIDATE INPUT ==========
 
-  if (!is.numeric(n) || length(n) != 1 || is.na(n) ||
+  if (!is.numeric(n) || length(n) != 1 || is.na(n) || !is.finite(n) ||
       n < 0 || n != trunc(n)) {
     stop("n must be a non-negative whole number.", call. = FALSE)
   }

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -223,6 +223,14 @@ create_mock_data <- function(databaseStart,
                              validate = TRUE,
                              verbose = FALSE) {
 
+  if (missing(databaseStart)) {
+    stop(
+      "databaseStart is required. Pass the database or cycle name that ",
+      "matches your metadata's databaseStart values (e.g. \"cycle1\").",
+      call. = FALSE
+    )
+  }
+
   # ========== LOAD METADATA ==========
 
   variables <- .load_metadata_df(variables, "variables", verbose = verbose)

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -19,7 +19,7 @@
 
     distribution <- tolower(variable$distribution %||% "uniform")
     if (variable$type == "continuous") {
-      return(!distribution %in% c("uniform", "normal"))
+      return(!distribution %in% c("uniform", "normal", "exponential"))
     }
     if (variable$type == "categorical") {
       return(FALSE)

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -237,8 +237,9 @@ create_mock_data <- function(databaseStart,
 
   # ========== VALIDATE INPUT ==========
 
-  if (n < 1) {
-    stop("n must be at least 1")
+  if (!is.numeric(n) || length(n) != 1 || is.na(n) ||
+      n < 0 || n != trunc(n)) {
+    stop("n must be a non-negative whole number.", call. = FALSE)
   }
 
   if (!"variable" %in% names(variables)) {

--- a/R/mock_spec.R
+++ b/R/mock_spec.R
@@ -259,6 +259,7 @@ mock_spec <- function(...,
 #' @param distribution Distribution name. Defaults to `"uniform"`.
 #' @param mean,sd Optional distribution parameters. Required when
 #'   `distribution = "normal"`.
+#' @param rate Rate parameter; required when `distribution = "exponential"`.
 #' @param rtype R output type. Defaults to `"double"`.
 #' @param missing_codes Explicit missing-code values.
 #' @param missing_proportions Missing-code probabilities aligned to
@@ -289,6 +290,7 @@ mock_continuous <- function(name,
                             distribution = "uniform",
                             mean = NA_real_,
                             sd = NA_real_,
+                            rate = NA_real_,
                             rtype = "double",
                             missing_codes = numeric(0),
                             missing_proportions = numeric(0),
@@ -305,6 +307,7 @@ mock_continuous <- function(name,
       distribution = distribution,
       mean = mean,
       sd = sd,
+      rate = rate,
       rtype = rtype,
       missing_codes = missing_codes,
       missing_proportions = missing_proportions,
@@ -454,6 +457,7 @@ mock_date <- function(name,
 #' @param range Numeric vector of length two giving the inclusive valid range.
 #' @param distribution Distribution name. Defaults to `"uniform"`.
 #' @param mean,sd Optional distribution parameters.
+#' @param rate Rate parameter; required when `distribution = "exponential"`.
 #' @param rtype R output type. Defaults to `"double"`.
 #' @param missing_codes Explicit missing-code values.
 #' @param missing_proportions Missing-code probabilities aligned to
@@ -482,6 +486,7 @@ mock_spec_continuous <- function(name,
                                  distribution = "uniform",
                                  mean = NA_real_,
                                  sd = NA_real_,
+                                 rate = NA_real_,
                                  rtype = "double",
                                  missing_codes = numeric(0),
                                  missing_proportions = numeric(0),
@@ -496,6 +501,7 @@ mock_spec_continuous <- function(name,
     range = range,
     mean = mean,
     sd = sd,
+    rate = rate,
     missing_codes = missing_codes,
     missing_proportions = missing_proportions,
     garbage_rules = garbage_rules,
@@ -795,6 +801,15 @@ print.mock_spec_validation_result <- function(x, ...) {
       }
       if (is.null(variable$sd) || length(variable$sd) != 1 || is.na(variable$sd) || variable$sd <= 0) {
         errors <- c(errors, paste0("Variable '", variable$name, "' normal distribution requires sd > 0."))
+      }
+    }
+    if (identical(variable$distribution, "exponential")) {
+      if (is.null(variable$rate) || length(variable$rate) != 1 ||
+          is.na(variable$rate) || variable$rate <= 0) {
+        errors <- c(errors, paste0(
+          "Variable '", variable$name,
+          "' exponential distribution requires rate > 0."
+        ))
       }
     }
   } else if (variable$type == "categorical") {

--- a/R/mock_spec.R
+++ b/R/mock_spec.R
@@ -114,6 +114,10 @@ NULL
     stop("mock_spec variable type must be a non-empty string.", call. = FALSE)
   }
 
+  if (!is.null(distribution)) {
+    distribution <- tolower(distribution)
+  }
+
   .validate_model_hint(model_hint)
 
   structure(
@@ -290,6 +294,7 @@ mock_spec <- function(...,
 #'   distribution = "exponential",
 #'   rate = 0.1
 #' )
+#' validate_mock_spec(wait_spec)
 #'
 #' @export
 mock_continuous <- function(name,
@@ -907,7 +912,8 @@ validate_mock_spec <- function(spec, n = NULL, strict = TRUE) {
   }
 
   if (!is.null(n)) {
-    if (!is.numeric(n) || length(n) != 1 || is.na(n) || n < 0 || n != floor(n)) {
+    if (!is.numeric(n) || length(n) != 1 || is.na(n) || !is.finite(n) ||
+        n < 0 || n != floor(n)) {
       errors <- c(errors, "n must be a non-negative whole number.")
     }
   }

--- a/R/mock_spec.R
+++ b/R/mock_spec.R
@@ -259,8 +259,8 @@ mock_spec <- function(...,
 #' @param distribution Distribution name. Defaults to `"uniform"`.
 #' @param mean,sd Optional distribution parameters. Required when
 #'   `distribution = "normal"`.
-#' @param rate Rate parameter; required when `distribution = "exponential"`.
 #' @param rtype R output type. Defaults to `"double"`.
+#' @param rate Rate parameter; required when `distribution = "exponential"`.
 #' @param missing_codes Explicit missing-code values.
 #' @param missing_proportions Missing-code probabilities aligned to
 #'   `missing_codes`.
@@ -284,14 +284,21 @@ mock_spec <- function(...,
 #' )
 #' validate_mock_spec(age_spec)
 #'
+#' wait_spec <- mock_continuous(
+#'   "wait",
+#'   range = c(0, 100),
+#'   distribution = "exponential",
+#'   rate = 0.1
+#' )
+#'
 #' @export
 mock_continuous <- function(name,
                             range,
                             distribution = "uniform",
                             mean = NA_real_,
                             sd = NA_real_,
-                            rate = NA_real_,
                             rtype = "double",
+                            rate = NA_real_,
                             missing_codes = numeric(0),
                             missing_proportions = numeric(0),
                             garbage_rules = list(),
@@ -457,8 +464,8 @@ mock_date <- function(name,
 #' @param range Numeric vector of length two giving the inclusive valid range.
 #' @param distribution Distribution name. Defaults to `"uniform"`.
 #' @param mean,sd Optional distribution parameters.
-#' @param rate Rate parameter; required when `distribution = "exponential"`.
 #' @param rtype R output type. Defaults to `"double"`.
+#' @param rate Rate parameter; required when `distribution = "exponential"`.
 #' @param missing_codes Explicit missing-code values.
 #' @param missing_proportions Missing-code probabilities aligned to
 #'   `missing_codes`.
@@ -480,14 +487,21 @@ mock_date <- function(name,
 #'   rtype = "integer"
 #' )
 #'
+#' wait_spec <- mock_spec_continuous(
+#'   "wait",
+#'   range = c(0, 100),
+#'   distribution = "exponential",
+#'   rate = 0.1
+#' )
+#'
 #' @export
 mock_spec_continuous <- function(name,
                                  range,
                                  distribution = "uniform",
                                  mean = NA_real_,
                                  sd = NA_real_,
-                                 rate = NA_real_,
                                  rtype = "double",
+                                 rate = NA_real_,
                                  missing_codes = numeric(0),
                                  missing_proportions = numeric(0),
                                  garbage_rules = list(),

--- a/R/mock_spec_native.R
+++ b/R/mock_spec_native.R
@@ -105,8 +105,15 @@
   values
 }
 
+# Exact truncation via inverse-CDF (pexp/qexp): exponential's CDF is
+# closed-form and invertible, so no rejection-sampling fallback is needed
+# (contrast .native_truncated_normal above).
 #' @noRd
 .native_truncated_exponential <- function(n, rate, range, variable_name) {
+  if (n == 0) {
+    return(numeric(0))
+  }
+
   lower <- range[[1]]
   upper <- range[[2]]
   p_lower <- stats::pexp(lower, rate = rate)
@@ -302,7 +309,8 @@
 #' @details
 #' The native backend is the default MIT-licensed baseline engine. It currently
 #' supports uniform continuous variables, truncated-normal continuous variables,
-#' categorical variables, and uniform calendar dates. Missing codes, garbage
+#' truncated-exponential continuous variables, categorical variables, and
+#' uniform calendar dates. Missing codes, garbage
 #' values, and diagnostics are intentionally handled by [postprocess_mock_data()]
 #' so that all backends share the same audit trail.
 #'

--- a/R/mock_spec_native.R
+++ b/R/mock_spec_native.R
@@ -106,6 +106,23 @@
 }
 
 #' @noRd
+.native_truncated_exponential <- function(n, rate, range, variable_name) {
+  lower <- range[[1]]
+  upper <- range[[2]]
+  p_lower <- stats::pexp(lower, rate = rate)
+  p_upper <- stats::pexp(upper, rate = rate)
+  if (!is.finite(p_lower) || !is.finite(p_upper) || p_upper <= p_lower) {
+    stop(
+      "Variable '", variable_name,
+      "' exponential distribution has no probability mass inside range [",
+      lower, ", ", upper, "].",
+      call. = FALSE
+    )
+  }
+  stats::qexp(stats::runif(n, p_lower, p_upper), rate = rate)
+}
+
+#' @noRd
 .coerce_native_continuous <- function(values, rtype, variable_name) {
   if (rtype == "integer") {
     return(as.integer(round(values)))
@@ -196,6 +213,13 @@
       n,
       variable$mean,
       variable$sd,
+      variable$range,
+      variable$name
+    )
+  } else if (distribution == "exponential") {
+    values <- .native_truncated_exponential(
+      n,
+      variable$rate,
       variable$range,
       variable$name
     )

--- a/R/mock_spec_recodeflow.R
+++ b/R/mock_spec_recodeflow.R
@@ -339,6 +339,7 @@
       distribution = distribution,
       mean = .row_numeric(var_row, "mean"),
       sd = .row_numeric(var_row, "sd"),
+      rate = .row_numeric(var_row, "rate"),
       rtype = rtype,
       missing_codes = missing$codes,
       missing_proportions = missing$proportions,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,34 @@
+# CRAN Comments
+
+## Local check
+
+Checked with:
+
+- R 4.4.2
+- macOS 26.5, aarch64-apple-darwin20
+- `R CMD check --as-cran --no-manual`
+
+Result:
+
+- 0 errors
+- 0 warnings
+- 3 notes
+
+Notes:
+
+- New submission.
+- `simstudy` was not installed in the local check environment, so the local
+  check used `_R_CHECK_FORCE_SUGGESTS_=false`. `simstudy` is listed in
+  `Suggests` and is used only for the optional backend.
+- The local check reported `unable to verify current time`.
+
+## Release notes
+
+This is the first CRAN submission of MockData. The package generates mock
+testing data from metadata specifications supplied as data frames or CSV files.
+It supports categorical, continuous, date, garbage-data, and survival-style
+variables for testing data pipelines and documentation examples.
+
+MockData generates mock data for software testing and workflow validation. It
+does not generate privacy-preserving synthetic data for inference or data
+release.

--- a/development/post-v040-development-plan.md
+++ b/development/post-v040-development-plan.md
@@ -1,0 +1,601 @@
+# Post-v0.4.0 Development Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement Phase 1 task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Phase 2 and 3 tasks are **design-first**: their deliverable is an ADR, and implementation is gated on maintainer approval of that ADR — do not write feature code for a Phase 2/3 workstream until its ADR is merged.
+
+**Goal:** Sequence and specify all post-v0.4.0 work — tactical hardening now, the v0.5 feature train (formulas, seed contract, survival pairs) next, the Table 1 adapter after — so any capable model or developer can execute it without re-deriving context.
+
+**Architecture:** MockData v0.4 is a layered pipeline: input adapters (direct API, recodeflow metadata) → normalized `mock_spec` → backends (native, optional simstudy) → post-processing (missing codes, garbage, coercion) with a `mockdata_diagnostics` attribute. Phase 1 hardens the orchestrator entry layer without touching output semantics. Phase 2 lands the two output-changing features plus the seed contract in a single coordinated minor release. Phase 3 adds a third input adapter.
+
+**Tech Stack:** R (>= 4.2.0), testthat (edition 3), roxygen2, renv, Quarto vignettes via pkgdown, GitHub Actions CI.
+
+**Plan date:** 2026-07-03. **Baseline:** `dev` branch at v0.4.0 + CRAN-readiness prep (`cran-comments.md`; no near-term submission planned).
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- R version floor **>= 4.2.0**; renv lockfile baseline 4.4.2.
+- After any `DESCRIPTION` dependency change: `renv::snapshot()` and commit `renv.lock`. Snapshot type is `"all"` — do not change it.
+- CI locale is `en_US.UTF-8`, never `en_CA` (Ubuntu runners lack it; silently breaks date parsing — see `.claude/AI.md`).
+- Always `roxygen2::roxygenize()` before `pkgdown::build_site()`. Quarto vignettes require `minimal: true`; callouts unsupported.
+- Never commit `*.Rcheck/`, `MockData_*.tar.gz`, `.tmp/`.
+- Commit messages: plain imperative sentences matching repo history (e.g. "Add native exponential distribution"); **no** conventional-commit prefixes; **no** AI credit; review commits with the maintainer before pushing.
+- **Release-stability constraint (Phase 1):** CRAN submission is not imminent — `cran-comments.md` was prepared as a readiness assessment, not an active submission. v0.4.x patches nonetheless stay additive: no public API surface changes, no seeded-output changes, error-relaxations allowed, each with a NEWS entry. This keeps a CRAN submission possible at any time and protects downstream consumers.
+- **Downstream constraint:** cchsflow and chmsflow (CRAN-published) consume the recodeflow metadata schema. Any change to shared-column semantics requires coordination — MockData-extension columns are the safe channel.
+- **Seed policy:** exactly one seeded-output break is budgeted, in v0.5, covered by one NEWS migration note (precedent: v0.3→v0.4 divergence). No other task may alter seeded output.
+- TDD throughout: failing test → minimal code → green → commit. Run `devtools::test()` (full) or `testthat::test_file("tests/testthat/<file>")` (single) each cycle.
+- Test fixtures: always `system.file(...)` + skip guard, never source-tree-relative paths (issue #33 item 7 lesson).
+
+## How to Use This Plan (two tiers)
+
+- **Phase 1 (Tasks 1–4)** is execution-ready: complete code in every step, verified against the tree at plan date. Execute directly.
+- **Phase 2 (Tasks 5–8) and Phase 3 (Task 9)** are design-first: the deliverable is an ADR whose decision points are enumerated below with evidence and a recommendation. After the maintainer approves an ADR, write a fresh implementation plan for that workstream (superpowers:writing-plans; save to `development/plans/YYYY-MM-DD-<workstream>.md`) and execute it. Do not skip the ADR gate.
+
+## Evidence Base
+
+Verified 2026-07-03 by direct probe (`devtools::load_all()` + minimal-example fixtures) and code reading.
+
+### Edge-case probe results
+
+| Call | Behaviour at plan date | Verdict |
+|---|---|---|
+| `generate_mock_data_native(mock_spec(), n = 10)` | 10 × 0 data frame | correct — pin (Task 1) |
+| `generate_mock_data_native(mock_spec(), n = 0)` | 0 × 0 data frame | correct — pin |
+| `generate_mock_data_native(<1-var spec>, n = 0)` | 0 × 1, typed column | correct — pin |
+| native, `n = -1` / `1.5` / `NA` | error "n must be a non-negative whole number." | correct — pin |
+| `postprocess_mock_data(<0-row baseline>, spec)` | 0-row, schema preserved | correct — pin |
+| `create_mock_data(db, vars, dets, n = 0)` | error "n must be at least 1" | **inconsistent** — fix (Task 2) |
+| `create_mock_data(db, vars, dets, n = 1.5)` | accepted (guard is `n < 1`) | **bug** — fix (Task 2) |
+| `create_mock_data()` without `databaseStart` | raw R missing-argument error | **UX gap** — fix (Task 3) |
+| `create_mock_data(db, vars[0, ], dets, n = 5)` | error "No variables matched the requested role/database filters." | correct — pin |
+| `create_mock_data(db, vars[1, ], dets, n = 5)` | 5 × 1 | correct — pin |
+| `create_mock_data(db, vars, NULL, n = 5)` | 5 × **11** (vs 5 × **6** with details) | discrepancy — record on #14, do **not** fix in Phase 1 |
+| native `distribution = "exponential"` | error "Native backend does not yet support..." | parity gap — fix (Task 4) |
+
+### Key code locations
+
+- `n < 1` guard: `R/create_mock_data.R:240-242`.
+- v0.4 seed split (`seed`, `seed + 1L`): `R/create_mock_data.R:85-90`. Legacy global `set.seed`: `:325-327`.
+- Native continuous dispatch (uniform/normal only, else stop): `R/mock_spec_native.R:189-211`. Truncated normal helper: `:75`.
+- Legacy exponential support: `R/create_con_var.R:279-281` (`rexp`, unbounded).
+- Adapter already stores `rate`/`shape`/`followup_min`/`followup_max`/`event_prop` on spec variables: `R/mock_spec_recodeflow.R:365-369`.
+- Spec variable constructor already has unused `formula` and `depends_on` fields plus `...` passthrough: `R/mock_spec.R:94-145`.
+- Validator normal-distribution block (pattern for exponential rule): `R/mock_spec.R:790-799`.
+- Formula-evaluator spike (referent validation, `str2lang` dependency extraction, topological ordering, cycle detection): recover with `git show f4f9b41:development/v04-simstudy-spike/prototype.R` (merged PR #27, later removed from tree).
+
+### Issue map
+
+| Issue | Workstream | Phase |
+|---|---|---|
+| [#35](https://github.com/Big-Life-Lab/MockData/issues/35) | Edge-case contract tests | 1 / Task 1 |
+| [#36](https://github.com/Big-Life-Lab/MockData/issues/36) | Entry-validation alignment | 1 / Tasks 2–3 |
+| [#37](https://github.com/Big-Life-Lab/MockData/issues/37) | Native exponential parity | 1 / Task 4 |
+| [#38](https://github.com/Big-Life-Lab/MockData/issues/38) | Seed-contract ADR | 2 / Task 5 |
+| [#39](https://github.com/Big-Life-Lab/MockData/issues/39) | Formula-derived variables | 2 / Task 6 |
+| [#40](https://github.com/Big-Life-Lab/MockData/issues/40) | Survival pairs in batch | 2 / Task 7 |
+| [#41](https://github.com/Big-Life-Lab/MockData/issues/41) | Table 1 adapter | 3 / Task 9 |
+| [#42](https://github.com/Big-Life-Lab/MockData/issues/42) | Correlations (deferred) | register |
+| [#43](https://github.com/Big-Life-Lab/MockData/issues/43) | LinkML (deferred, ecosystem) | register |
+
+Related pre-existing: #13 (umbrella reassessment — outcome is this plan), #14 (fallback semantics — evidence recorded by Task 1), #17, #22 (fulfilled by #38), #23 (direction fulfilled by #40), #24 (enabled by #37), #33 (tactical debt, complementary to Phase 1), #25 (spike — suggest close).
+
+### Execution order
+
+```
+Phase 1 (v0.4.x, now):   Task 1 → Task 2 → Task 3 → Task 4
+Phase 2 (v0.5):          Task 5 (ADR) ─┬→ Task 8 (release train)
+                         Task 6 (ADR) ─┤   [Tasks 5+6 land together: one seed break]
+                         Task 7 (ADR) ─┘   [Task 7 may land same release; no seed impact]
+Phase 3 (v0.6):          Task 9 (ADR → adapter)
+Register (triggered):    #42 after Task 5 lands + concrete need; #43 on ecosystem demand
+```
+
+---
+
+## Phase 1 — v0.4.x hardening (execution-ready)
+
+No public API surface changes; no seeded-output changes. Each task is one PR-sized unit.
+
+### Task 1: Edge-case contract tests (#35)
+
+**Files:**
+- Create: `tests/testthat/test-edge-case-contract.R`
+
+**Interfaces:**
+- Consumes: exported `mock_spec()`, `mock_continuous()`, `generate_mock_data_native()`, `postprocess_mock_data()`, `create_mock_data()`; fixture `inst/extdata/minimal-example/`.
+- Produces: nothing for later tasks — pure characterization. Tasks 2–3 extend this same file.
+
+- [ ] **Step 1: Write the contract tests** (all should pass immediately — they pin verified current behaviour)
+
+```r
+# tests/testthat/test-edge-case-contract.R
+# Characterization tests pinning the edge-case input contract (issue #35).
+# Probe evidence: development/post-v040-development-plan.md, Evidence Base.
+
+minimal_example <- function() {
+  vars <- system.file("extdata", "minimal-example", "variables.csv",
+                      package = "MockData")
+  dets <- system.file("extdata", "minimal-example", "variable_details.csv",
+                      package = "MockData")
+  if (!nzchar(vars) || !nzchar(dets)) {
+    skip("minimal-example fixtures not installed")
+  }
+  list(
+    variables = read.csv(vars, stringsAsFactors = FALSE, check.names = FALSE),
+    variable_details = read.csv(dets, stringsAsFactors = FALSE, check.names = FALSE)
+  )
+}
+
+test_that("native backend returns typed zero-row output for n = 0", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  result <- generate_mock_data_native(spec, n = 0)
+  expect_s3_class(result, "data.frame")
+  expect_identical(nrow(result), 0L)
+  expect_named(result, "age")
+  expect_type(result$age, "double")
+})
+
+test_that("native backend returns n rows and zero columns for an empty spec", {
+  expect_identical(dim(generate_mock_data_native(mock_spec(), n = 10)), c(10L, 0L))
+  expect_identical(dim(generate_mock_data_native(mock_spec(), n = 0)), c(0L, 0L))
+})
+
+test_that("native backend rejects invalid n with a clear message", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  expect_error(generate_mock_data_native(spec, n = -1),
+               "non-negative whole number")
+  expect_error(generate_mock_data_native(spec, n = 1.5),
+               "non-negative whole number")
+  expect_error(generate_mock_data_native(spec, n = NA),
+               "non-negative whole number")
+})
+
+test_that("postprocess_mock_data preserves zero-row shape and names", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  baseline <- generate_mock_data_native(spec, n = 0)
+  result <- postprocess_mock_data(baseline, spec)
+  expect_identical(nrow(result), 0L)
+  expect_named(result, "age")
+})
+
+test_that("create_mock_data fails loudly when no variables match filters", {
+  fx <- minimal_example()
+  expect_error(
+    suppressMessages(create_mock_data(
+      "minimal-example", fx$variables[0, ], fx$variable_details, n = 5
+    )),
+    "No variables matched"
+  )
+})
+
+test_that("create_mock_data handles single-row variables metadata", {
+  fx <- minimal_example()
+  result <- suppressMessages(create_mock_data(
+    "minimal-example", fx$variables[1, ], fx$variable_details, n = 5
+  ))
+  expect_identical(nrow(result), 5L)
+  expect_identical(ncol(result), 1L)
+})
+
+test_that("create_mock_data generates the minimal example (sanity anchor)", {
+  fx <- minimal_example()
+  result <- suppressMessages(create_mock_data(
+    "minimal-example", fx$variables, fx$variable_details, n = 20, seed = 1
+  ))
+  expect_identical(nrow(result), 20L)
+  expect_true(all(c("age", "smoking") %in% names(result)))
+  expect_true(all(names(result) %in% fx$variables$variable))
+})
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `Rscript -e 'devtools::load_all(quiet = TRUE); testthat::test_file("tests/testthat/test-edge-case-contract.R")'`
+Expected: all PASS, 0 failures. If any cell fails, current behaviour has drifted from the plan-date probe — stop and re-verify against the Evidence Base before changing either test or code.
+
+- [ ] **Step 3: Record the fallback discrepancy on issue #14** (evidence, not a fix)
+
+Run: `gh issue comment 14 --repo Big-Life-Lab/MockData --body "Concrete evidence (2026-07-03 probe, plan Task 1): create_mock_data(\"minimal-example\", vars, dets, n = 5) returns 6 columns; the same call with variable_details = NULL returns 11 columns via the legacy fallback. Fallback filtering semantics differ from the details path."`
+
+- [ ] **Step 4: Full suite, then commit**
+
+Run: `Rscript -e 'devtools::test()'` — expected: green, no new skips.
+
+```bash
+git add tests/testthat/test-edge-case-contract.R
+git commit -m "Pin edge-case input contract with characterization tests
+
+Closes #35. Evidence recorded on #14."
+```
+
+### Task 2: Allow n = 0 and validate n properly in create_mock_data() (#36)
+
+**Files:**
+- Modify: `R/create_mock_data.R:240-242`
+- Modify: `tests/testthat/test-edge-case-contract.R` (extend)
+- Modify: `NEWS.md` (add "MockData (development version)" heading if absent)
+
+**Interfaces:**
+- Consumes: guard block at `R/create_mock_data.R:240-242` exactly as shown in Evidence Base.
+- Produces: unified n-validation message `"n must be a non-negative whole number."` — Task 3 appends to the same test file; the message string is relied on by tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/testthat/test-edge-case-contract.R`:
+
+```r
+test_that("create_mock_data accepts n = 0 and returns a full-schema empty frame", {
+  fx <- minimal_example()
+  result <- suppressMessages(create_mock_data(
+    "minimal-example", fx$variables, fx$variable_details, n = 0
+  ))
+  expect_identical(nrow(result), 0L)
+  expect_true(all(c("age", "smoking") %in% names(result)))
+})
+
+test_that("create_mock_data rejects fractional, negative, and NA n clearly", {
+  fx <- minimal_example()
+  for (bad_n in list(1.5, -1, NA)) {
+    expect_error(
+      suppressMessages(create_mock_data(
+        "minimal-example", fx$variables, fx$variable_details, n = bad_n
+      )),
+      "non-negative whole number"
+    )
+  }
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `Rscript -e 'devtools::load_all(quiet = TRUE); testthat::test_file("tests/testthat/test-edge-case-contract.R")'`
+Expected: FAIL — n = 0 errors "n must be at least 1"; n = 1.5 does not error.
+
+- [ ] **Step 3: Replace the guard**
+
+In `R/create_mock_data.R`, replace exactly:
+
+```r
+  if (n < 1) {
+    stop("n must be at least 1")
+  }
+```
+
+with:
+
+```r
+  if (!is.numeric(n) || length(n) != 1 || is.na(n) ||
+      n < 0 || n != trunc(n)) {
+    stop("n must be a non-negative whole number.", call. = FALSE)
+  }
+```
+
+- [ ] **Step 4: Run the tests again**
+
+Expected: the two new tests pass. **Bounded contingency:** if the n = 0 test now fails *deeper* in the pipeline, the spec-layer contract (verified: 0-row generation works) means the failure is orchestrator glue — fix the failing helper to propagate a zero-row frame, keeping the fix minimal. If the failure is on the **legacy** path only (`validate = FALSE`), instead add after the new guard:
+
+```r
+  if (n == 0 && !validate) {
+    stop("n = 0 requires validate = TRUE (v0.4 pipeline).", call. = FALSE)
+  }
+```
+
+and pin that with:
+
+```r
+test_that("legacy path states its n = 0 limitation clearly", {
+  fx <- minimal_example()
+  expect_error(
+    suppressMessages(create_mock_data(
+      "minimal-example", fx$variables, fx$variable_details, n = 0, validate = FALSE
+    )),
+    "requires validate = TRUE"
+  )
+})
+```
+
+- [ ] **Step 5: NEWS entry**
+
+Under a `# MockData (development version)` heading at the top of `NEWS.md`:
+
+```markdown
+- `create_mock_data()` now accepts `n = 0`, returning a zero-row data frame
+  with the full generated schema (useful for schema tests), and rejects
+  fractional, negative, and `NA` values of `n` with a clear message. The
+  validation now matches `generate_mock_data_native()`.
+```
+
+- [ ] **Step 6: Full suite, roxygenize (no roxygen changes expected, cheap safety), commit**
+
+Run: `Rscript -e 'devtools::test()'` — expected green.
+
+```bash
+git add R/create_mock_data.R tests/testthat/test-edge-case-contract.R NEWS.md
+git commit -m "Allow n = 0 in create_mock_data() and align n validation with the spec layer
+
+Relates to #36."
+```
+
+### Task 3: Friendly upfront databaseStart check (#36)
+
+**Files:**
+- Modify: `R/create_mock_data.R` (top of function body, before `.load_metadata_df()` calls)
+- Modify: `tests/testthat/test-edge-case-contract.R` (extend)
+
+**Interfaces:**
+- Consumes: `create_mock_data()` signature — `databaseStart` is the first positional parameter with no default.
+- Produces: error message beginning `"databaseStart is required"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```r
+test_that("missing databaseStart produces a named, friendly error", {
+  fx <- minimal_example()
+  expect_error(
+    create_mock_data(variables = fx$variables,
+                     variable_details = fx$variable_details, n = 5),
+    "databaseStart is required"
+  )
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Expected: FAIL — current error is R's raw `argument "databaseStart" is missing, with no default`.
+
+- [ ] **Step 3: Add the check**
+
+At the top of the `create_mock_data()` function body (immediately after the opening brace, before `# ========== LOAD METADATA ==========`):
+
+```r
+  if (missing(databaseStart)) {
+    stop(
+      "databaseStart is required. Pass the database or cycle name that ",
+      "matches your metadata's databaseStart values (e.g. \"cycle1\").",
+      call. = FALSE
+    )
+  }
+```
+
+- [ ] **Step 4: Run tests — expected PASS. Full suite — expected green.**
+
+- [ ] **Step 5: NEWS + commit**
+
+Append to the development-version NEWS block:
+
+```markdown
+- Calling `create_mock_data()` without `databaseStart` now fails upfront with
+  a message naming the argument, instead of a raw missing-argument error.
+```
+
+```bash
+git add R/create_mock_data.R tests/testthat/test-edge-case-contract.R NEWS.md
+git commit -m "Check databaseStart upfront in create_mock_data()
+
+Closes #36."
+```
+
+### Task 4: Native exponential distribution (#37)
+
+**Files:**
+- Modify: `R/mock_spec.R` (`mock_continuous()` at :287, `mock_spec_continuous()` at :480, validator continuous block at :790-799)
+- Modify: `R/mock_spec_native.R` (`.generate_native_continuous()` at :189; new helper next to `.native_truncated_normal()` at :75)
+- Create: `tests/testthat/test-native-exponential.R`
+- Modify: `NEWS.md`
+
+**Interfaces:**
+- Consumes: `.new_mock_spec_variable()` `...` passthrough (extra named fields land on the variable list — this is how `rate` becomes `variable$rate`); validator pattern of the normal block; `.native_truncated_normal()` as the structural template.
+- Produces: `mock_continuous(..., rate =)`, `mock_spec_continuous(..., rate =)`, `.native_truncated_exponential(n, rate, range, variable_name)`; validator error string `"exponential distribution requires rate > 0"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```r
+# tests/testthat/test-native-exponential.R
+test_that("native exponential generates within the declared range", {
+  spec <- mock_continuous("wait", range = c(0, 100),
+                          distribution = "exponential", rate = 0.1)
+  result <- generate_mock_data_native(spec, n = 500, seed = 42)
+  expect_true(all(result$wait >= 0 & result$wait <= 100))
+  expect_type(result$wait, "double")
+})
+
+test_that("native exponential is seed-reproducible", {
+  spec <- mock_continuous("wait", range = c(0, 100),
+                          distribution = "exponential", rate = 0.1)
+  expect_identical(
+    generate_mock_data_native(spec, n = 50, seed = 7),
+    generate_mock_data_native(spec, n = 50, seed = 7)
+  )
+})
+
+test_that("exponential without a positive rate is rejected", {
+  # Constructors document that they return a validated mock_spec; expect the
+  # error at construction. If construction is lazy in this version, assert on
+  # validate_mock_spec(spec, strict = FALSE)$errors instead.
+  expect_error(
+    mock_continuous("wait", range = c(0, 100), distribution = "exponential"),
+    "exponential distribution requires rate > 0"
+  )
+})
+
+test_that("recodeflow-sourced rate flows to the native generator", {
+  spec <- mock_continuous("wait", range = c(0, 50),
+                          distribution = "exponential", rate = 0.5)
+  result <- generate_mock_data_native(spec, n = 200, seed = 11)
+  # rate = 0.5 on [0, 50]: truncated mean ~ 2; loose two-sided sanity bound
+  expect_gt(mean(result$wait), 0.5)
+  expect_lt(mean(result$wait), 6)
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `Rscript -e 'devtools::load_all(quiet = TRUE); testthat::test_file("tests/testthat/test-native-exponential.R")'`
+Expected: FAIL — `unused argument (rate = 0.1)` from `mock_continuous()`.
+
+- [ ] **Step 3: Add `rate` to both constructors**
+
+In `mock_continuous()` (`R/mock_spec.R:287`), add the parameter after `sd = NA_real_`:
+
+```r
+                            sd = NA_real_,
+                            rate = NA_real_,
+```
+
+and forward it inside the `mock_spec_continuous(...)` call:
+
+```r
+      mean = mean,
+      sd = sd,
+      rate = rate,
+```
+
+In `mock_spec_continuous()` (`R/mock_spec.R:480`), same pattern — parameter after `sd = NA_real_`, and forward inside `.new_mock_spec_variable(...)`:
+
+```r
+    mean = mean,
+    sd = sd,
+    rate = rate,
+```
+
+(`.new_mock_spec_variable()` accepts `...`, so `rate` lands on the variable list as `variable$rate`.)
+
+Add roxygen `@param rate Rate parameter; required when `distribution = "exponential"`.` to both constructors' documentation blocks.
+
+- [ ] **Step 4: Add the validator rule**
+
+In `.validate_mock_spec_variable()` (`R/mock_spec.R`), directly after the closing brace of the `if (identical(variable$distribution, "normal")) {...}` block (:792-799):
+
+```r
+    if (identical(variable$distribution, "exponential")) {
+      if (is.null(variable$rate) || length(variable$rate) != 1 ||
+          is.na(variable$rate) || variable$rate <= 0) {
+        errors <- c(errors, paste0(
+          "Variable '", variable$name,
+          "' exponential distribution requires rate > 0."
+        ))
+      }
+    }
+```
+
+- [ ] **Step 5: Add the generator branch and helper**
+
+In `.generate_native_continuous()` (`R/mock_spec_native.R:189`), insert before the final `else { stop(...) }`:
+
+```r
+  } else if (distribution == "exponential") {
+    values <- .native_truncated_exponential(
+      n,
+      variable$rate,
+      variable$range,
+      variable$name
+    )
+```
+
+New helper, placed immediately after `.native_truncated_normal()`:
+
+```r
+#' @noRd
+.native_truncated_exponential <- function(n, rate, range, variable_name) {
+  lower <- range[[1]]
+  upper <- range[[2]]
+  p_lower <- stats::pexp(lower, rate = rate)
+  p_upper <- stats::pexp(upper, rate = rate)
+  if (!is.finite(p_lower) || !is.finite(p_upper) || p_upper <= p_lower) {
+    stop(
+      "Variable '", variable_name,
+      "' exponential distribution has no probability mass inside range [",
+      lower, ", ", upper, "].",
+      call. = FALSE
+    )
+  }
+  stats::qexp(stats::runif(n, p_lower, p_upper), rate = rate)
+}
+```
+
+- [ ] **Step 6: Run the test file — expected PASS. Then `Rscript -e 'devtools::document()'` and full suite — expected green.**
+
+- [ ] **Step 7: NEWS + commit**
+
+```markdown
+- The native backend now supports `distribution = "exponential"` (parity with
+  the legacy generator), removing a forced legacy-fallback for exponential
+  metadata. Unlike the legacy `rexp()`, native exponential values are
+  truncated to the declared `range`, consistent with the native normal
+  distribution.
+```
+
+```bash
+git add R/mock_spec.R R/mock_spec_native.R tests/testthat/test-native-exponential.R NEWS.md man/
+git commit -m "Add exponential distribution to the native backend
+
+Closes #37. Enables the exponential half of #24 on the native path."
+```
+
+---
+
+## Phase 2 — v0.5 feature train (design-first; ADR gate before implementation)
+
+Tasks 5 and 6 **must land in the same minor release**: both change seeded output, and the budget is one break with one NEWS migration note. Task 7 has no seed impact and may ride along.
+
+### Task 5: Seed-contract ADR (#38)
+
+**Deliverable:** `development/adr/v05-seed-contract.md`, approved by the maintainer.
+
+- [ ] **Step 1: Draft the ADR** with these sections and decision points:
+  - **Context:** three regimes (legacy global `set.seed` at `R/create_mock_data.R:325-327`; v0.4 `seed`/`seed + 1L` at `:85-90`; simstudy backend's own handling); fallback stream-switch is verbose-gated (#33 item 11).
+  - **Options:** (a) document the status quo; (b) L'Ecuyer-CMRG sub-streams via `parallel::nextRNGStream()`, one stream per stage; (c) hash-derived per-stage (or per-variable) integer seeds. **Recommendation: (b) at stage granularity** — principled, base-R only, and per-variable granularity is YAGNI until parallel generation is on the table.
+  - **Guarantee scope:** same seed + same spec + same package version ⇒ identical output; stability across minor versions explicitly *not* guaranteed when NEWS declares a break.
+  - **Migration:** single break, coordinated with Task 6; pinned-value regression tests (fulfils #22); decide whether the fallback stream-switch message becomes always-on (#33 item 11).
+- [ ] **Step 2: Maintainer review — STOP until approved.**
+- [ ] **Step 3: Write the implementation plan** (superpowers:writing-plans → `development/plans/`) and execute.
+
+### Task 6: Formula-evaluator ADR + implementation (#39)
+
+**Deliverable:** `development/adr/v05-formula-evaluator.md`, approved; then phased implementation.
+
+- [ ] **Step 1: Recover the spike:** `git show f4f9b41:development/v04-simstudy-spike/prototype.R > /tmp/spike-prototype.R` and read it. It contains `formula_dependencies()` (`all.vars(str2lang(...))`), topological ordering with cycle detection ("Formula dependency cycle or unresolved ordering among: ..."), and `validate_formula_referents()`.
+- [ ] **Step 2: Draft the ADR** with these decision points:
+  - **Syntax entry:** (a) new MockData-extension column (e.g. `mockFormula`) vs (b) reuse `variableStart` `DerivedVar::`/`Func::`. **Recommendation: (a)** — cchsflow/chmsflow are CRAN downstreams; do not overload shared recodeflow semantics. `identify_derived_vars()` continues to detect-and-skip `DerivedVar::` entries that carry no `mockFormula`.
+  - **Evaluation environment:** restricted env containing only generated columns + an enumerated whitelist of base math/logic functions (`+ - * / ^ %% < <= > >= == != & | ! ifelse pmin pmax log exp sqrt abs round`); no filesystem, network, or global lookup. List the exact whitelist in the ADR.
+  - **Phasing:** Phase A — algebraic formulas over generated columns (spec fields `formula`/`depends_on` already exist, `R/mock_spec.R:94-145`). Phase B — `Func::` dispatch to the consuming package's namespace (define lookup order and failure semantics).
+  - **Diagnostics:** derived columns get a `derived = TRUE` entry in `mockdata_diagnostics` with their dependency list.
+- [ ] **Step 3: Maintainer review — STOP until approved.**
+- [ ] **Step 4: Implementation plan + execution.** Required tests: referent validation errors, cycle detection message, deterministic ordering, seed reproducibility under the Task 5 contract.
+
+### Task 7: Survival pairs in batch generation (#40)
+
+**Deliverable:** short design note (may be a section in the implementation plan rather than a full ADR), then implementation.
+
+- [ ] **Step 1: Decide the pairing convention** — recommendation: an explicit `anchor` extension column on the event variable's metadata row naming its entry-date variable. Metadata fields `followup_min`/`followup_max`/`event_prop` already flow (`R/mock_spec_recodeflow.R:367-369`).
+- [ ] **Step 2: Define the multi-column generator contract** — a spec variable of type `survival` returns a 2-column data frame; the assembly loop accepts multi-column returns; `validate_mock_spec()` checks the anchor exists, is a date variable, and ordering constraints hold.
+- [ ] **Step 3: Implementation plan + execution.** Required tests: event/censoring proportions with two-sided bounds (#23's direction); diagnostics attribute both columns to one spec entry; NEWS removes the standing known-issue entry.
+
+### Task 8: v0.5 release assembly
+
+- [ ] Tasks 5 + 6 merged together; one NEWS migration section covering the seeded-output break with before/after guidance.
+- [ ] Pinned-value seed regression tests in place (#22 closed).
+- [ ] `devtools::check()` clean; `roxygen2::roxygenize()` then `pkgdown::build_site()` clean; `renv::snapshot()` if dependencies moved.
+- [ ] Version bump to 0.5.0; downstream heads-up to cchsflow/chmsflow maintainers if any metadata-extension columns were added.
+
+---
+
+## Phase 3 — v0.6
+
+### Task 9: Table 1 bootstrap adapter (#41)
+
+**Deliverable:** `development/adr/v06-table1-adapter.md` (short), then `mock_spec_from_table1()`.
+
+Strict-schema v1 only — tidy input data frame (`variable`, `type`, `level`, `prop`, `mean`, `sd`, `min`, `max`) → validated `mock_spec`. Explicit v1 exclusions (in the issue and the ADR): no median/IQR conversion, no stratified panels, no document/PDF parsing, and a vignette-level scope statement that outputs match *marginals* for testing and teaching — not synthetic data for inference or release (the `cran-comments.md` boundary). Design can begin any time; implementation targets v0.6.
+
+## Deferred register (do not schedule; activate on trigger)
+
+- **Correlated variables (#42):** trigger = seed ADR (#38) landed **and** a concrete derived-variable test that cannot get coverage from independent marginals. simstudy-backend-only; plausibility-not-fidelity documentation mandatory.
+- **LinkML / schema-first (#43):** trigger = a second ecosystem consumer needs formal schema validation. First step is an org-level ADR in a recodeflow ecosystem repo — not MockData code.
+- **Distribution registry:** no issue filed — YAGNI. The path, should demand appear, is more native built-ins (Task 4 pattern), not a public registration API.
+
+## Self-review (performed at plan date)
+
+- **Coverage:** all eight assessed improvement areas map to a task or register entry; issues #35–#43 cross-linked; pre-existing #13/#14/#22/#23/#24/#25/#33 reconciled.
+- **Placeholder scan:** Phase 1 steps contain complete code verified against the tree; the two bounded contingencies (Task 2 Step 4, Task 4 Step 1's construction-vs-lazy validation note) provide exact code for both branches rather than deferring the decision.
+- **Type consistency:** `rate` flows constructor → `...` → `variable$rate` → validator → `.native_truncated_exponential()`; message strings quoted in tests match the code that raises them.

--- a/development/post-v040-development-plan.md
+++ b/development/post-v040-development-plan.md
@@ -226,9 +226,9 @@ Append to `tests/testthat/test-edge-case-contract.R`:
 ```r
 test_that("create_mock_data accepts n = 0 and returns a full-schema empty frame", {
   fx <- minimal_example()
-  result <- suppressMessages(create_mock_data(
+  result <- suppressWarnings(suppressMessages(create_mock_data(
     "minimal-example", fx$variables, fx$variable_details, n = 0
-  ))
+  )))
   expect_identical(nrow(result), 0L)
   expect_true(all(c("age", "smoking") %in% names(result)))
 })

--- a/development/post-v040-development-plan.md
+++ b/development/post-v040-development-plan.md
@@ -179,9 +179,9 @@ test_that("create_mock_data handles single-row variables metadata", {
 
 test_that("create_mock_data generates the minimal example (sanity anchor)", {
   fx <- minimal_example()
-  result <- suppressMessages(create_mock_data(
+  result <- suppressWarnings(suppressMessages(create_mock_data(
     "minimal-example", fx$variables, fx$variable_details, n = 20, seed = 1
-  ))
+  )))
   expect_identical(nrow(result), 20L)
   expect_true(all(c("age", "smoking") %in% names(result)))
   expect_true(all(names(result) %in% fx$variables$variable))

--- a/development/post-v040-development-plan.md
+++ b/development/post-v040-development-plan.md
@@ -435,10 +435,10 @@ Expected: FAIL — `unused argument (rate = 0.1)` from `mock_continuous()`.
 
 - [ ] **Step 3: Add `rate` to both constructors**
 
-In `mock_continuous()` (`R/mock_spec.R:287`), add the parameter after `sd = NA_real_`:
+In `mock_continuous()` (`R/mock_spec.R:287`), add the parameter after `rtype = "double"`:
 
 ```r
-                            sd = NA_real_,
+                            rtype = "double",
                             rate = NA_real_,
 ```
 
@@ -450,7 +450,7 @@ and forward it inside the `mock_spec_continuous(...)` call:
       rate = rate,
 ```
 
-In `mock_spec_continuous()` (`R/mock_spec.R:480`), same pattern — parameter after `sd = NA_real_`, and forward inside `.new_mock_spec_variable(...)`:
+In `mock_spec_continuous()` (`R/mock_spec.R:480`), same pattern — parameter after `rtype = "double"`, and forward inside `.new_mock_spec_variable(...)`:
 
 ```r
     mean = mean,

--- a/inst/extdata/minimal-example/README.md
+++ b/inst/extdata/minimal-example/README.md
@@ -190,7 +190,7 @@ v_005,,,0.03,[2099-01-01,2099-12-31]     # primary_event: 3% future dates
 ### Basic mock data generation
 
 ```r
-library(mockData)
+library(MockData)
 
 # Load metadata
 variables <- read.csv("inst/extdata/minimal-example/variables.csv",

--- a/tests/testthat/test-create-mock-data-v04.R
+++ b/tests/testthat/test-create-mock-data-v04.R
@@ -38,13 +38,17 @@ test_that("create_mock_data uses the v0.4 pipeline for strict supported metadata
 })
 
 test_that("create_mock_data keeps legacy fallback for unsupported v0.4 backend features", {
+  # "lognormal" is not among the native backend's supported continuous
+  # distributions (uniform/normal/exponential), so this pins the v0.4
+  # orchestrator's fallback-to-legacy behaviour for a still-unsupported
+  # distribution. (Exponential moved to the native path in #37; see
+  # test-native-exponential.R for its coverage.)
   variables <- data.frame(
     variable = "time_to_visit",
     variableType = "Continuous",
     rType = "double",
     role = "enabled",
-    distribution = "exponential",
-    rate = 0.5,
+    distribution = "lognormal",
     stringsAsFactors = FALSE
   )
   variable_details <- data.frame(

--- a/tests/testthat/test-edge-case-contract.R
+++ b/tests/testthat/test-edge-case-contract.R
@@ -1,0 +1,78 @@
+# tests/testthat/test-edge-case-contract.R
+# Characterization tests pinning the edge-case input contract (issue #35).
+# Probe evidence: development/post-v040-development-plan.md, Evidence Base.
+
+minimal_example <- function() {
+  vars <- system.file("extdata", "minimal-example", "variables.csv",
+                      package = "MockData")
+  dets <- system.file("extdata", "minimal-example", "variable_details.csv",
+                      package = "MockData")
+  if (!nzchar(vars) || !nzchar(dets)) {
+    skip("minimal-example fixtures not installed")
+  }
+  list(
+    variables = read.csv(vars, stringsAsFactors = FALSE, check.names = FALSE),
+    variable_details = read.csv(dets, stringsAsFactors = FALSE, check.names = FALSE)
+  )
+}
+
+test_that("native backend returns typed zero-row output for n = 0", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  result <- generate_mock_data_native(spec, n = 0)
+  expect_s3_class(result, "data.frame")
+  expect_identical(nrow(result), 0L)
+  expect_named(result, "age")
+  expect_type(result$age, "double")
+})
+
+test_that("native backend returns n rows and zero columns for an empty spec", {
+  expect_identical(dim(generate_mock_data_native(mock_spec(), n = 10)), c(10L, 0L))
+  expect_identical(dim(generate_mock_data_native(mock_spec(), n = 0)), c(0L, 0L))
+})
+
+test_that("native backend rejects invalid n with a clear message", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  expect_error(generate_mock_data_native(spec, n = -1),
+               "non-negative whole number")
+  expect_error(generate_mock_data_native(spec, n = 1.5),
+               "non-negative whole number")
+  expect_error(generate_mock_data_native(spec, n = NA),
+               "non-negative whole number")
+})
+
+test_that("postprocess_mock_data preserves zero-row shape and names", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  baseline <- generate_mock_data_native(spec, n = 0)
+  result <- postprocess_mock_data(baseline, spec)
+  expect_identical(nrow(result), 0L)
+  expect_named(result, "age")
+})
+
+test_that("create_mock_data fails loudly when no variables match filters", {
+  fx <- minimal_example()
+  expect_error(
+    suppressMessages(create_mock_data(
+      "minimal-example", fx$variables[0, ], fx$variable_details, n = 5
+    )),
+    "No variables matched"
+  )
+})
+
+test_that("create_mock_data handles single-row variables metadata", {
+  fx <- minimal_example()
+  result <- suppressMessages(create_mock_data(
+    "minimal-example", fx$variables[1, ], fx$variable_details, n = 5
+  ))
+  expect_identical(nrow(result), 5L)
+  expect_identical(ncol(result), 1L)
+})
+
+test_that("create_mock_data generates the minimal example (sanity anchor)", {
+  fx <- minimal_example()
+  result <- suppressMessages(create_mock_data(
+    "minimal-example", fx$variables, fx$variable_details, n = 20, seed = 1
+  ))
+  expect_identical(nrow(result), 20L)
+  expect_true(all(c("age", "smoking") %in% names(result)))
+  expect_true(all(names(result) %in% fx$variables$variable))
+})

--- a/tests/testthat/test-edge-case-contract.R
+++ b/tests/testthat/test-edge-case-contract.R
@@ -76,3 +76,24 @@ test_that("create_mock_data generates the minimal example (sanity anchor)", {
   expect_true(all(c("age", "smoking") %in% names(result)))
   expect_true(all(names(result) %in% fx$variables$variable))
 })
+
+test_that("create_mock_data accepts n = 0 and returns a full-schema empty frame", {
+  fx <- minimal_example()
+  result <- suppressMessages(create_mock_data(
+    "minimal-example", fx$variables, fx$variable_details, n = 0
+  ))
+  expect_identical(nrow(result), 0L)
+  expect_true(all(c("age", "smoking") %in% names(result)))
+})
+
+test_that("create_mock_data rejects fractional, negative, and NA n clearly", {
+  fx <- minimal_example()
+  for (bad_n in list(1.5, -1, NA)) {
+    expect_error(
+      suppressMessages(create_mock_data(
+        "minimal-example", fx$variables, fx$variable_details, n = bad_n
+      )),
+      "non-negative whole number"
+    )
+  }
+})

--- a/tests/testthat/test-edge-case-contract.R
+++ b/tests/testthat/test-edge-case-contract.R
@@ -69,9 +69,9 @@ test_that("create_mock_data handles single-row variables metadata", {
 
 test_that("create_mock_data generates the minimal example (sanity anchor)", {
   fx <- minimal_example()
-  result <- suppressMessages(create_mock_data(
+  result <- suppressWarnings(suppressMessages(create_mock_data(
     "minimal-example", fx$variables, fx$variable_details, n = 20, seed = 1
-  ))
+  )))
   expect_identical(nrow(result), 20L)
   expect_true(all(c("age", "smoking") %in% names(result)))
   expect_true(all(names(result) %in% fx$variables$variable))

--- a/tests/testthat/test-edge-case-contract.R
+++ b/tests/testthat/test-edge-case-contract.R
@@ -97,3 +97,12 @@ test_that("create_mock_data rejects fractional, negative, and NA n clearly", {
     )
   }
 })
+
+test_that("missing databaseStart produces a named, friendly error", {
+  fx <- minimal_example()
+  expect_error(
+    create_mock_data(variables = fx$variables,
+                     variable_details = fx$variable_details, n = 5),
+    "databaseStart is required"
+  )
+})

--- a/tests/testthat/test-edge-case-contract.R
+++ b/tests/testthat/test-edge-case-contract.R
@@ -38,6 +38,8 @@ test_that("native backend rejects invalid n with a clear message", {
                "non-negative whole number")
   expect_error(generate_mock_data_native(spec, n = NA),
                "non-negative whole number")
+  expect_error(generate_mock_data_native(spec, n = Inf),
+               "non-negative whole number")
 })
 
 test_that("postprocess_mock_data preserves zero-row shape and names", {
@@ -88,7 +90,7 @@ test_that("create_mock_data accepts n = 0 and returns a full-schema empty frame"
 
 test_that("create_mock_data rejects fractional, negative, and NA n clearly", {
   fx <- minimal_example()
-  for (bad_n in list(1.5, -1, NA)) {
+  for (bad_n in list(1.5, -1, NA, Inf)) {
     expect_error(
       suppressMessages(create_mock_data(
         "minimal-example", fx$variables, fx$variable_details, n = bad_n

--- a/tests/testthat/test-edge-case-contract.R
+++ b/tests/testthat/test-edge-case-contract.R
@@ -79,9 +79,9 @@ test_that("create_mock_data generates the minimal example (sanity anchor)", {
 
 test_that("create_mock_data accepts n = 0 and returns a full-schema empty frame", {
   fx <- minimal_example()
-  result <- suppressMessages(create_mock_data(
+  result <- suppressWarnings(suppressMessages(create_mock_data(
     "minimal-example", fx$variables, fx$variable_details, n = 0
-  ))
+  )))
   expect_identical(nrow(result), 0L)
   expect_true(all(c("age", "smoking") %in% names(result)))
 })

--- a/tests/testthat/test-native-exponential.R
+++ b/tests/testthat/test-native-exponential.R
@@ -77,3 +77,73 @@ test_that("recodeflow-sourced rate flows through create_mock_data to the native 
   )
   expect_identical(result, repeat_result)
 })
+
+test_that("exponential rejects zero and negative rate", {
+  expect_error(
+    mock_continuous("wait", range = c(0, 100), distribution = "exponential", rate = 0),
+    "exponential distribution requires rate > 0"
+  )
+  expect_error(
+    mock_continuous("wait", range = c(0, 100), distribution = "exponential", rate = -1),
+    "exponential distribution requires rate > 0"
+  )
+})
+
+test_that("distribution case is normalized so validation applies", {
+  expect_error(
+    mock_continuous("wait", range = c(0, 100), distribution = "Exponential"),
+    "exponential distribution requires rate > 0"
+  )
+})
+
+test_that("no-probability-mass guard fires for degenerate and far-tail ranges", {
+  degenerate <- mock_continuous("wait", range = c(5, 5),
+                                distribution = "exponential", rate = 0.5)
+  expect_error(
+    generate_mock_data_native(degenerate, n = 10),
+    "no probability mass inside range"
+  )
+  far_tail <- mock_continuous("wait", range = c(1000, 2000),
+                              distribution = "exponential", rate = 10)
+  expect_error(
+    generate_mock_data_native(far_tail, n = 10),
+    "no probability mass inside range"
+  )
+})
+
+test_that("n = 0 returns an empty column even when the range has no mass", {
+  degenerate <- mock_continuous("wait", range = c(5, 5),
+                                distribution = "exponential", rate = 0.5)
+  result <- generate_mock_data_native(degenerate, n = 0)
+  expect_identical(nrow(result), 0L)
+  expect_named(result, "wait")
+})
+
+test_that("invalid exponential metadata fails with diagnosis and guidance", {
+  variables <- data.frame(
+    variable = "wait",
+    variableType = "Continuous",
+    rType = "double",
+    role = "enabled",
+    distribution = "exponential",
+    stringsAsFactors = FALSE
+  )
+  variable_details <- data.frame(
+    variable = "wait",
+    recStart = "[0, 50]",
+    recEnd = "copy",
+    proportion = 1,
+    stringsAsFactors = FALSE
+  )
+  err <- tryCatch(
+    suppressMessages(create_mock_data(
+      databaseStart = "study",
+      variables = variables,
+      variable_details = variable_details,
+      n = 5
+    )),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(err, "requires rate > 0")
+  expect_match(err, "validate = FALSE")
+})

--- a/tests/testthat/test-native-exponential.R
+++ b/tests/testthat/test-native-exponential.R
@@ -17,8 +17,7 @@ test_that("native exponential is seed-reproducible", {
 
 test_that("exponential without a positive rate is rejected", {
   # Constructors document that they return a validated mock_spec; expect the
-  # error at construction. If construction is lazy in this version, assert on
-  # validate_mock_spec(spec, strict = FALSE)$errors instead.
+  # error at construction.
   expect_error(
     mock_continuous("wait", range = c(0, 100), distribution = "exponential"),
     "exponential distribution requires rate > 0"

--- a/tests/testthat/test-native-exponential.R
+++ b/tests/testthat/test-native-exponential.R
@@ -25,11 +25,56 @@ test_that("exponential without a positive rate is rejected", {
   )
 })
 
-test_that("recodeflow-sourced rate flows to the native generator", {
+test_that("rate parameter shapes native exponential generation", {
   spec <- mock_continuous("wait", range = c(0, 50),
                           distribution = "exponential", rate = 0.5)
   result <- generate_mock_data_native(spec, n = 200, seed = 11)
   # rate = 0.5 on [0, 50]: truncated mean ~ 2; loose two-sided sanity bound
   expect_gt(mean(result$wait), 0.5)
   expect_lt(mean(result$wait), 6)
+})
+
+test_that("recodeflow-sourced rate flows through create_mock_data to the native generator", {
+  # Regression pin for #37: mock_spec_recodeflow.R forwards `rate` from
+  # metadata and create_mock_data.R's v0.4 allowlist includes "exponential".
+  # Without both fixes, this call hard-errors or silently falls back to the
+  # legacy path (no mockdata_diagnostics attribute).
+  variables <- data.frame(
+    variable = "wait",
+    variableType = "Continuous",
+    rType = "double",
+    role = "enabled",
+    distribution = "exponential",
+    rate = 0.5,
+    stringsAsFactors = FALSE
+  )
+  variable_details <- data.frame(
+    variable = "wait",
+    recStart = "[0, 50]",
+    recEnd = "copy",
+    proportion = 1,
+    stringsAsFactors = FALSE
+  )
+
+  result <- create_mock_data(
+    databaseStart = "study",
+    variables = variables,
+    variable_details = variable_details,
+    n = 200,
+    seed = 11,
+    validate = TRUE
+  )
+
+  expect_true(all(result$wait >= 0 & result$wait <= 50))
+  expect_false(is.null(attr(result, "mockdata_diagnostics")))
+
+  repeat_result <- create_mock_data(
+    databaseStart = "study",
+    variables = variables,
+    variable_details = variable_details,
+    n = 200,
+    seed = 11,
+    validate = TRUE
+  )
+  expect_identical(result, repeat_result)
 })

--- a/tests/testthat/test-native-exponential.R
+++ b/tests/testthat/test-native-exponential.R
@@ -1,0 +1,35 @@
+test_that("native exponential generates within the declared range", {
+  spec <- mock_continuous("wait", range = c(0, 100),
+                          distribution = "exponential", rate = 0.1)
+  result <- generate_mock_data_native(spec, n = 500, seed = 42)
+  expect_true(all(result$wait >= 0 & result$wait <= 100))
+  expect_type(result$wait, "double")
+})
+
+test_that("native exponential is seed-reproducible", {
+  spec <- mock_continuous("wait", range = c(0, 100),
+                          distribution = "exponential", rate = 0.1)
+  expect_identical(
+    generate_mock_data_native(spec, n = 50, seed = 7),
+    generate_mock_data_native(spec, n = 50, seed = 7)
+  )
+})
+
+test_that("exponential without a positive rate is rejected", {
+  # Constructors document that they return a validated mock_spec; expect the
+  # error at construction. If construction is lazy in this version, assert on
+  # validate_mock_spec(spec, strict = FALSE)$errors instead.
+  expect_error(
+    mock_continuous("wait", range = c(0, 100), distribution = "exponential"),
+    "exponential distribution requires rate > 0"
+  )
+})
+
+test_that("recodeflow-sourced rate flows to the native generator", {
+  spec <- mock_continuous("wait", range = c(0, 50),
+                          distribution = "exponential", rate = 0.5)
+  result <- generate_mock_data_native(spec, n = 200, seed = 11)
+  # rate = 0.5 on [0, 50]: truncated mean ~ 2; loose two-sided sanity bound
+  expect_gt(mean(result$wait), 0.5)
+  expect_lt(mean(result$wait), 6)
+})

--- a/vignettes/getting-started.qmd
+++ b/vignettes/getting-started.qmd
@@ -262,7 +262,7 @@ knitr::kable(details_display)
 - `catLabel`: Category label or range description
 - `proportion`: Probability of each category (categorical variables only)
 
-See [inst/extdata/minimal-example/](https://github.com/Big-Life-Lab/mockData/tree/main/inst/extdata/minimal-example) for the complete files and v0.2.1 schema documentation.
+See [inst/extdata/minimal-example/](https://github.com/Big-Life-Lab/MockData/tree/main/inst/extdata/minimal-example) for the complete files and v0.2.1 schema documentation.
 
 ## Working with the generated data
 

--- a/vignettes/migrating-from-v03-v04.qmd
+++ b/vignettes/migrating-from-v03-v04.qmd
@@ -197,8 +197,8 @@ is.null(attr(fallback_data, "mockdata_diagnostics"))
 ```
 
 Unsupported v0.4 backend features also route to legacy dispatch. This example
-uses an exponential continuous distribution, which remains available through the
-legacy generator.
+uses a lognormal continuous distribution, which is not yet supported by the
+v0.4 native backend and remains available through the legacy generator.
 
 ```{r}
 exp_variables <- data.frame(
@@ -206,8 +206,7 @@ exp_variables <- data.frame(
   variableType = "Continuous",
   rType = "double",
   role = "enabled",
-  distribution = "exponential",
-  rate = 0.5,
+  distribution = "lognormal",
   stringsAsFactors = FALSE
 )
 

--- a/vignettes/reference-config.qmd
+++ b/vignettes/reference-config.qmd
@@ -95,8 +95,8 @@ For complete column documentation, see sections below.
 
 This vignette uses inline R code to generate documentation directly from the actual example data. Column counts, CSV examples, and dataset summaries are calculated dynamically from:
 
-- [inst/extdata/minimal-example/variables.csv](https://github.com/Big-Life-Lab/mockData/tree/main/inst/extdata/minimal-example/variables.csv)
-- [inst/extdata/minimal-example/variable_details.csv](https://github.com/Big-Life-Lab/mockData/tree/main/inst/extdata/minimal-example/variable_details.csv)
+- [inst/extdata/minimal-example/variables.csv](https://github.com/Big-Life-Lab/MockData/blob/main/inst/extdata/minimal-example/variables.csv)
+- [inst/extdata/minimal-example/variable_details.csv](https://github.com/Big-Life-Lab/MockData/blob/main/inst/extdata/minimal-example/variable_details.csv)
 
 This approach ensures the documentation stays synchronized with the package and serves as integration testing during package builds.
 :::
@@ -2013,7 +2013,7 @@ variable_types <- table(variables_csv$variableType)
 rtypes <- table(variables_csv$rType)
 ```
 
-See [inst/extdata/minimal-example/](https://github.com/Big-Life-Lab/mockData/tree/main/inst/extdata/minimal-example) for a complete working example with `r n_variables` variables (`r paste(names(variable_types), ":", variable_types, collapse = ", ")`) and `r n_detail_rows` detail rows demonstrating:
+See [inst/extdata/minimal-example/](https://github.com/Big-Life-Lab/MockData/tree/main/inst/extdata/minimal-example) for a complete working example with `r n_variables` variables (`r paste(names(variable_types), ":", variable_types, collapse = ", ")`) and `r n_detail_rows` detail rows demonstrating:
 
 - All `r vars_counts$extensions` variable-level extension columns (plus `r vars_counts$core` core recodeflow columns)
 - All `r details_counts$extensions` detail-level extension columns (plus `r details_counts$core` core recodeflow columns)

--- a/vignettes/reference-config.qmd
+++ b/vignettes/reference-config.qmd
@@ -78,7 +78,7 @@ Essential columns for getting started:
 | `variable` | variables.csv | Yes | Output column name | `"age"` |
 | `variableType` | variables.csv | Yes | Categorical or Continuous (from recodeflow) | `"Continuous"` |
 | `rType` | variables.csv | No | R output type (integer, double, character, date, factor) | `"integer"` |
-| `distribution` | variables.csv | Continuous/Date | normal, uniform, gompertz | `"normal"` |
+| `distribution` | variables.csv | Continuous/Date | normal, uniform, exponential, gompertz | `"normal"` |
 | `mean`, `sd` | variables.csv | Normal dist | Distribution parameters | `50`, `15` |
 | `garbage_low_prop` | variables.csv | No | QA testing (low values) | `0.01` |
 | `garbage_high_prop` | variables.csv | No | QA testing (high values) | `0.03` |
@@ -211,12 +211,17 @@ v006,death_date,NA,"[,]",NA,"[,]",0.02
 
 - `"normal"` - Normal (Gaussian) distribution (requires `mean`, `sd`)
 - `"uniform"` - Uniform distribution over valid range
+- `"exponential"` - Exponential distribution, truncated to the valid range (requires `rate`)
 
 **For date variables:**
 
 - `"uniform"` - Equal probability for all dates
 - `"gompertz"` - Age-related hazard (requires `rate`, `shape`, `followup_min`, `followup_max`, `event_prop`)
 - `"exponential"` - Constant hazard (requires `rate`, `followup_min`, `followup_max`, `event_prop`)
+
+The `followup_min`, `followup_max`, and `event_prop` fields apply only to the
+date/survival use of `exponential`. For continuous variables, `exponential`
+requires only `rate`.
 
 **For categorical variables:** Set to `NA` (categories defined by proportions in variable_details.csv)
 
@@ -797,6 +802,7 @@ See [Working with date variables](tutorial-dates.html#source-data-format-simulat
 |--------------|---------------------|----------|---------|
 | `normal` | `mean`, `sd` | Age, BMI, normally-distributed measurements | Age: mean=50, sd=15 |
 | `uniform` | None (uses recStart range) | Equal probability across range | Income brackets, uniform codes |
+| `exponential` | `rate` | Exponential distribution, truncated to the valid range | Wait times, time-to-event measurements |
 
 **For date variables:**
 
@@ -805,6 +811,10 @@ See [Working with date variables](tutorial-dates.html#source-data-format-simulat
 | `uniform` | None | Index dates, enrollment dates | Interview date |
 | `gompertz` | `rate`, `shape`, `followup_min`, `followup_max`, `event_prop` | Age-related events (death, dementia) | Mortality with increasing hazard by age |
 | `exponential` | `rate`, `followup_min`, `followup_max`, `event_prop` | Constant hazard events | Loss to follow-up |
+
+Note: the `followup_min`, `followup_max`, and `event_prop` parameters above
+apply only to the date/survival use of `exponential`. The continuous-variable
+`exponential` distribution requires only `rate`.
 
 **Complete examples:**
 

--- a/vignettes/tutorial-dates.qmd
+++ b/vignettes/tutorial-dates.qmd
@@ -557,7 +557,7 @@ old_dates_sample <- head(sort(diag_data$diagnosis_date[diag_data$diagnosis_date 
 -   **Training analysts:** Show examples of real-world data quality issues
 -   **Data cleaning scripts:** Test date range checks and filtering logic
 
-**Note:** For complete examples of garbage date generation integrated into metadata files, see the [minimal-example configuration files](https://github.com/Big-Life-Lab/mockData/tree/main/inst/extdata/minimal-example).
+**Note:** For complete examples of garbage date generation integrated into metadata files, see the [minimal-example configuration files](https://github.com/Big-Life-Lab/MockData/tree/main/inst/extdata/minimal-example).
 
 ## Checking generated dates
 


### PR DESCRIPTION
Phase 1 of the post-v0.4.0 development plan (`development/post-v040-development-plan.md`). Four tasks, each TDD with per-task review, plus a final whole-branch review.

## Changes

- **Edge-case contract tests** (#35) — new `tests/testthat/test-edge-case-contract.R` pins verified behaviour: zero-row/zero-column generation, n validation messages, loud zero-metadata failure, single-row metadata. Evidence of the 6-vs-11-column fallback discrepancy recorded on #14. No production-code changes.
- **Entry-validation alignment** (#36) — `create_mock_data()` now accepts `n = 0` (full-schema zero-row frame), rejects fractional/negative/NA `n` with the spec layer's message (previously `n = 1.5` was silently accepted), and fails upfront with a named error when `databaseStart` is missing.
- **Native exponential distribution** (#37) — `rate` parameter on both continuous constructors, validator rule, inverse-CDF range-truncated generator (documented difference from the unbounded legacy `rexp()`), recodeflow adapter rate-forwarding, and orchestrator allowlist update so exponential metadata routes natively instead of falling back to the legacy engine. Covered end-to-end including a recodeflow-metadata integration test.

## Review notes

- Final review verdict: ready to merge. One API decision made during review: `rate` sits after `rtype` in the constructor signatures to preserve positional compatibility.
- Adapter change verified backward-compatible for downstream metadata without a `rate` column (cchsflow/chmsflow).
- Follow-up filed: #44 (`is.finite(n)` in both guards).
- Suite at branch head: FAIL 0 | WARN 35 (pre-existing) | SKIP 10 (pre-existing) | PASS 673.

Closes #35. Closes #36. Closes #37.