### PR TITLE
v0.5 seed & RNG-stream contract (#38)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ VignetteBuilder: quarto
 Depends:
     R (>= 4.2.0)
 Imports:
+    parallel,
     stats
 Suggests:
     testthat (>= 3.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,9 @@
   Mersenne-Twister `seed` / `seed + 1` scheme. For a given seed **and package
   version** output is reproducible and independent of the session's ambient
   `RNGkind()`; it is not comparable across the v0.4 → v0.5 boundary. Pin your
-  own expected values against the version you use. Generation no longer alters
-  the caller's RNG state on any path (previously the legacy `validate = FALSE`
-  path reset it).
+  own expected values against the version you use. For seeded calls,
+  generation no longer alters the caller's RNG state (previously the legacy
+  `validate = FALSE` path reset it).
 
 - `create_mock_data()` now accepts `n = 0`, returning a zero-row data frame
   with the full generated schema (useful for schema tests), and rejects

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,15 +2,22 @@
 
 ## Reproducibility (breaking change)
 
-- Seeded output changed once in this release. MockData now derives all
-  randomness from independent L'Ecuyer-CMRG sub-streams (one per generation
-  stage) seeded from the single public `seed`, replacing the previous
-  Mersenne-Twister `seed` / `seed + 1` scheme. For a given seed **and package
-  version** output is reproducible and independent of the session's ambient
-  `RNGkind()`; it is not comparable across the v0.4 → v0.5 boundary. Pin your
-  own expected values against the version you use. For seeded calls,
-  generation no longer alters the caller's RNG state (previously the legacy
-  `validate = FALSE` path reset it).
+- Seeded output changed once for the RNG-stream mechanism in this release.
+  Within the `create_mock_data()` pipeline (`generate_mock_data_native()`,
+  `generate_mock_data_simstudy()`, `postprocess_mock_data()`), MockData now
+  derives all randomness from independent L'Ecuyer-CMRG sub-streams (one per
+  generation stage) seeded from the single public `seed`, replacing the
+  previous Mersenne-Twister `seed` / `seed + 1` scheme. The standalone
+  `create_*` helpers (`create_cat_var()`, `create_con_var()`,
+  `create_date_var()`, `create_survival_dates()`,
+  `create_wide_survival_data()`, `sample_with_proportions()`,
+  `make_garbage()`, `apply_garbage()`) called directly are unaffected and
+  still seed a single Mersenne-Twister stream per call. For a given seed
+  **and package version** pipeline output is reproducible and independent of
+  the session's ambient `RNGkind()`; it is not comparable across the v0.4 →
+  v0.5 boundary. Pin your own expected values against the version you use.
+  For seeded calls, generation no longer alters the caller's RNG state
+  (previously the legacy `validate = FALSE` path reset it).
 
 - `create_mock_data()` now accepts `n = 0`, returning a zero-row data frame
   with the full generated schema (useful for schema tests), and rejects

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # MockData (development version)
 
+## Reproducibility (breaking change)
+
+- Seeded output changed once in this release. MockData now derives all
+  randomness from independent L'Ecuyer-CMRG sub-streams (one per generation
+  stage) seeded from the single public `seed`, replacing the previous
+  Mersenne-Twister `seed` / `seed + 1` scheme. For a given seed **and package
+  version** output is reproducible and independent of the session's ambient
+  `RNGkind()`; it is not comparable across the v0.4 → v0.5 boundary. Pin your
+  own expected values against the version you use. Generation no longer alters
+  the caller's RNG state on any path (previously the legacy `validate = FALSE`
+  path reset it).
+
 - `create_mock_data()` now accepts `n = 0`, returning a zero-row data frame
   with the full generated schema (useful for schema tests), and rejects
   fractional, negative, `NA`, and non-finite values of `n` with a clear

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -295,6 +295,11 @@ create_mock_data <- function(databaseStart,
     if (!is.null(v04_result)) {
       return(v04_result)
     }
+
+    message(
+      "Falling back to the legacy generator for an unsupported v0.4 feature; ",
+      "for a given seed this produces different values than the v0.4 pipeline."
+    )
   }
 
   # ========== FILTER FOR ENABLED VARIABLES ==========
@@ -343,13 +348,6 @@ create_mock_data <- function(databaseStart,
             paste(enabled_vars$variable, collapse = ", "))
   }
 
-  # ========== SET GLOBAL SEED ==========
-
-  if (!is.null(seed)) {
-    if (verbose) message("Setting random seed: ", seed)
-    set.seed(seed)
-  }
-
   # ========== GENERATE VARIABLES ==========
 
   if (verbose) message("Generating ", n, " observations...")
@@ -370,6 +368,8 @@ create_mock_data <- function(databaseStart,
   )
 
   # Generate variables in order
+  .with_mock_seed(seed, stage = "baseline", {
+  if (!is.null(seed) && verbose) message("Setting random seed: ", seed)
   for (i in seq_len(nrow(enabled_vars))) {
     var_row <- enabled_vars[i, ]
     var_name <- var_row$variable
@@ -447,6 +447,7 @@ create_mock_data <- function(databaseStart,
       skipped_vars <- c(skipped_vars, var_name)
     }
   }
+  })
 
   # ========== RETURN RESULT ==========
 

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -172,7 +172,7 @@
 #' \enumerate{
 #'   \item Load metadata from file paths or accept data frames
 #'   \item Filter for enabled variables (role has an exact "enabled" token)
-#'   \item Set global seed (if provided)
+#'   \item Generate within an isolated RNG sub-stream (if seeded), leaving the caller's RNG state untouched
 #'   \item Loop through variables in position order:
 #'     - Dispatch to create_cat_var, create_con_var, or create_date_var
 #'     - Pass full metadata data frames (functions filter internally)
@@ -448,6 +448,23 @@ create_mock_data <- function(databaseStart,
     }
   }
   })
+
+  # An empty result is legitimate when every enabled variable was explicitly
+  # tracked as skipped (e.g. validate = FALSE + an unsupported rType, warned
+  # and recorded above). It is NOT legitimate when variables were enabled and
+  # none were recorded as skipped - that combination can only happen if the
+  # seed-scoping block above failed to propagate its assignments back to this
+  # frame. Guard against the latter, not the former.
+  if (ncol(df_mock) == 0L && nrow(enabled_vars) > 0L &&
+      length(unique(skipped_vars)) < nrow(enabled_vars)) {
+    stop(
+      "Internal error: no variables were generated despite ", nrow(enabled_vars),
+      " enabled variable(s), and not all were recorded as skipped. The ",
+      "seed-scoping wrapper may have failed to propagate results to the ",
+      "caller frame - please file a bug report.",
+      call. = FALSE
+    )
+  }
 
   # ========== RETURN RESULT ==========
 

--- a/R/create_mock_data.R
+++ b/R/create_mock_data.R
@@ -96,11 +96,10 @@
   }
 
   baseline <- generate_mock_data_native(spec, n = n, seed = seed)
-  # The wrapper uses a second deterministic stream for post-processing so
-  # baseline generation and missing/garbage assignment can be reproduced
-  # independently from the single public seed.
-  postprocess_seed <- if (is.null(seed)) NULL else seed + 1L
-  postprocess_mock_data(baseline, spec, seed = postprocess_seed)
+  # Baseline and post-processing use distinct L'Ecuyer-CMRG sub-streams derived
+  # from the single public seed (see .with_mock_seed / ADR v05-seed-contract),
+  # so both stages pass the same seed and select their own stage internally.
+  postprocess_mock_data(baseline, spec, seed = seed)
 }
 
 #' Create mock data from configuration files
@@ -161,9 +160,9 @@
 #' variable uses a feature not yet supported by the v0.4 native backend. Set
 #' `verbose = TRUE` to see which path was chosen.
 #'
-#' In the v0.4 path, `seed` is used for baseline generation and `seed + 1` is
-#' used for post-processing. This makes both stages deterministic, but generated
-#' values may differ from v0.3.x output for the same seed.
+#' In the v0.4 path, baseline generation and post-processing draw from distinct,
+#' independent sub-streams derived from a single `seed`; output is reproducible
+#' for a given seed and package version but changed in v0.5 (see NEWS).
 #'
 #' **v0.3.0 API**: This function follows the "recodeflow pattern" where it passes
 #' full metadata data frames to create_* functions, which handle internal

--- a/R/mock_spec_native.R
+++ b/R/mock_spec_native.R
@@ -5,8 +5,19 @@
 # garbage, diagnostics, and richer rType handling lands in later milestones.
 # ==============================================================================
 
+# Named generation stages -> fixed L'Ecuyer-CMRG sub-stream indices. Indices
+# are FROZEN: adding a future stage must not renumber baseline/postprocess, or
+# seeded output for existing features would shift. formula (#39) and correlate
+# (#42) are reserved now though unused in this release.
+.MOCK_STAGES <- c(
+  baseline    = 0L,
+  postprocess = 1L,
+  formula     = 2L,
+  correlate   = 3L
+)
+
 #' @noRd
-.with_mock_seed <- function(seed, expr) {
+.with_mock_seed <- function(seed, expr, stage = "baseline") {
   if (is.null(seed)) {
     return(force(expr))
   }
@@ -14,14 +25,18 @@
   if (!is.numeric(seed) || length(seed) != 1 || is.na(seed) || seed != floor(seed)) {
     stop("seed must be a single whole number.", call. = FALSE)
   }
+  if (!stage %in% names(.MOCK_STAGES)) {
+    stop("Unknown generation stage: '", stage, "'.", call. = FALSE)
+  }
 
+  # Save the caller's RNG state AND kind so generation never perturbs them.
+  old_kind <- RNGkind()
   had_seed <- exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
   if (had_seed) {
     old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
   }
-
-  # Generation should be reproducible without changing the caller's RNG stream.
   on.exit({
+    RNGkind(kind = old_kind[1], normal.kind = old_kind[2], sample.kind = old_kind[3])
     if (had_seed) {
       assign(".Random.seed", old_seed, envir = .GlobalEnv)
     } else if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
@@ -29,7 +44,16 @@
     }
   }, add = TRUE)
 
-  set.seed(seed)
+  # One L'Ecuyer-CMRG stream from the public seed, advanced to this stage's
+  # provably-independent sub-stream. Pinning the kind makes output independent
+  # of the caller's ambient RNGkind().
+  set.seed(seed, kind = "L'Ecuyer-CMRG")
+  stream <- .Random.seed
+  for (i in seq_len(.MOCK_STAGES[[stage]])) {
+    stream <- parallel::nextRNGStream(stream)
+  }
+  assign(".Random.seed", stream, envir = .GlobalEnv)
+
   force(expr)
 }
 
@@ -354,5 +378,5 @@ generate_mock_data_native <- function(spec, n, seed = NULL) {
       names(columns) <- names(spec$variables)
       as.data.frame(columns, stringsAsFactors = FALSE, check.names = FALSE)
     }
-  })
+  }, stage = "baseline")
 }

--- a/R/mock_spec_native.R
+++ b/R/mock_spec_native.R
@@ -345,8 +345,10 @@
 #'
 #' @param spec A `mock_spec` object.
 #' @param n Non-negative whole number of rows to generate.
-#' @param seed Optional whole-number random seed. The previous R random state is
-#'   restored after generation.
+#' @param seed Optional whole-number seed. Generation uses an isolated
+#'   L'Ecuyer-CMRG sub-stream and restores the caller's RNG state and kind on
+#'   exit, so output is reproducible for a given seed and package version
+#'   without perturbing the caller's RNG.
 #'
 #' @return A data frame with one column per `mock_spec` variable and `n` rows.
 #' @family mock generation APIs

--- a/R/mock_spec_native.R
+++ b/R/mock_spec_native.R
@@ -18,15 +18,15 @@
 
 #' @noRd
 .with_mock_seed <- function(seed, expr, stage = "baseline") {
+  if (!stage %in% names(.MOCK_STAGES)) {
+    stop("Unknown generation stage: '", stage, "'.", call. = FALSE)
+  }
   if (is.null(seed)) {
     return(force(expr))
   }
 
   if (!is.numeric(seed) || length(seed) != 1 || is.na(seed) || seed != floor(seed)) {
     stop("seed must be a single whole number.", call. = FALSE)
-  }
-  if (!stage %in% names(.MOCK_STAGES)) {
-    stop("Unknown generation stage: '", stage, "'.", call. = FALSE)
   }
 
   # Save the caller's RNG state AND kind so generation never perturbs them.
@@ -36,7 +36,13 @@
     old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
   }
   on.exit({
-    RNGkind(kind = old_kind[1], normal.kind = old_kind[2], sample.kind = old_kind[3])
+    # Suppress: restoring the caller's own ambient RNGkind (e.g. sample.kind
+    # = "Rounding" from RNGversion("3.5.0")) would otherwise re-fire the
+    # "non-uniform 'Rounding' sampler used" warning on every seeded call -
+    # the caller already chose that kind and was already warned about it once.
+    suppressWarnings(
+      RNGkind(kind = old_kind[1], normal.kind = old_kind[2], sample.kind = old_kind[3])
+    )
     if (had_seed) {
       assign(".Random.seed", old_seed, envir = .GlobalEnv)
     } else if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
@@ -338,9 +344,7 @@
 #' values, and diagnostics are intentionally handled by [postprocess_mock_data()]
 #' so that all backends share the same audit trail.
 #'
-#' If `seed` is supplied, the previous R random state is restored after
-#' generation. This gives reproducible output without advancing the caller's RNG
-#' stream. Formula variables are rejected loudly until the formula/dependency
+#' Formula variables are rejected loudly until the formula/dependency
 #' milestone promotes the spike evaluator into production.
 #'
 #' @param spec A `mock_spec` object.

--- a/R/mock_spec_native.R
+++ b/R/mock_spec_native.R
@@ -47,7 +47,7 @@
   # One L'Ecuyer-CMRG stream from the public seed, advanced to this stage's
   # provably-independent sub-stream. Pinning the kind makes output independent
   # of the caller's ambient RNGkind().
-  set.seed(seed, kind = "L'Ecuyer-CMRG")
+  set.seed(seed, kind = "L'Ecuyer-CMRG", normal.kind = "Inversion", sample.kind = "Rejection")
   stream <- .Random.seed
   for (i in seq_len(.MOCK_STAGES[[stage]])) {
     stream <- parallel::nextRNGStream(stream)

--- a/R/mock_spec_postprocess.R
+++ b/R/mock_spec_postprocess.R
@@ -306,8 +306,10 @@
 #'
 #' @param data Data frame with one column for each variable in `spec`.
 #' @param spec A validated `mock_spec` object.
-#' @param seed Optional whole-number random seed. The previous R random state is
-#'   restored after post-processing.
+#' @param seed Optional whole-number seed. Generation uses an isolated
+#'   L'Ecuyer-CMRG sub-stream and restores the caller's RNG state and kind on
+#'   exit, so output is reproducible for a given seed and package version
+#'   without perturbing the caller's RNG.
 #' @param diagnostics Logical. If `TRUE`, attach a `mockdata_diagnostics`
 #'   attribute to the returned data frame.
 #'

--- a/R/mock_spec_postprocess.R
+++ b/R/mock_spec_postprocess.R
@@ -346,7 +346,7 @@
 #'   missing_proportions = 0.05
 #' )
 #' baseline <- generate_mock_data_native(spec, n = 20, seed = 1)
-#' result <- postprocess_mock_data(baseline, spec, seed = 2)
+#' result <- postprocess_mock_data(baseline, spec, seed = 1)
 #' attr(result, "mockdata_diagnostics")$variables$smoking
 #'
 #' @export

--- a/R/mock_spec_postprocess.R
+++ b/R/mock_spec_postprocess.R
@@ -390,5 +390,5 @@ postprocess_mock_data <- function(data, spec, seed = NULL, diagnostics = TRUE) {
     }
 
     output
-  })
+  }, stage = "postprocess")
 }

--- a/R/mock_spec_simstudy.R
+++ b/R/mock_spec_simstudy.R
@@ -204,8 +204,10 @@
 #'
 #' @param spec A `mock_spec` object.
 #' @param n Non-negative whole number of rows to generate.
-#' @param seed Optional whole-number random seed. The previous R random state is
-#'   restored after generation.
+#' @param seed Optional whole-number seed. Generation uses an isolated
+#'   L'Ecuyer-CMRG sub-stream and restores the caller's RNG state and kind on
+#'   exit, so output is reproducible for a given seed and package version
+#'   without perturbing the caller's RNG.
 #'
 #' @return A data frame with one column per `mock_spec` variable and `n` rows.
 #' @family mock generation APIs

--- a/R/mock_spec_simstudy.R
+++ b/R/mock_spec_simstudy.R
@@ -244,5 +244,5 @@ generate_mock_data_simstudy <- function(spec, n, seed = NULL) {
       stringsAsFactors = FALSE,
       check.names = FALSE
     )
-  })
+  }, stage = "baseline")
 }

--- a/development/adr/v05-seed-contract.md
+++ b/development/adr/v05-seed-contract.md
@@ -1,0 +1,266 @@
+# ADR: v0.5 Seed and RNG-Stream Contract
+
+**Status**: ACCEPTED 2026-07-06 — full-bundle contract, co-released with #39 in v0.5. Implementation is a separate ADR-gated plan (not yet written). Any individual decision below remains open to maintainer revision before implementation begins.
+**Date**: drafted 2026-07-03; accepted 2026-07-06
+**Decision owner**: MockData maintainers
+**Issue**: #38 (fulfils #22; resolves #33 item 11)
+
+## Decision summary
+
+| # | Question | Decision |
+|---|---|---|
+| D1 | Stream-derivation scheme | **(b)** L'Ecuyer-CMRG stage sub-streams via `parallel::nextRNGStream()` |
+| D2 | Isolation across paths | **(a)** Unify all three paths on save/restore (no path perturbs the caller's RNG) |
+| D3 | Guarantee scope | Ratified as stated: same seed + spec + **version** ⇒ identical output; not across minor versions |
+| D4 | Fallback stream-switch announcement | **(a)** Always-on, once-per-call message |
+| Timing | Release | **Co-release with #39** in v0.5 — one break, one NEWS note (maintainer-selected) |
+
+Rationale for the bundle: #39 (formula evaluator) reorders draws and so forces a
+seeded-output break in v0.5 independent of this ADR. Given that break is already
+budgeted and being spent, adopting the full principled contract in the same
+release is near-zero marginal cost, and it means #42 (correlations) later needs
+**no** further break. The minimal alternative would spend the #39 break without
+buying the contract, then require a second break for #42.
+
+## Context
+
+MockData accepts a single public `seed` argument and promises reproducible mock
+data. Today that promise is kept by three different mechanisms that do not agree
+on either *how the seed is consumed* or *whether generation perturbs the
+caller's random state*. Before v0.5 adds features that necessarily change seeded
+output — the formula evaluator (#39) reorders draws by dependency, correlated
+variables (#42) add a third RNG consumer — the contract must be defined once, so
+those features land as a single, well-documented reproducibility break rather
+than a series of silent ones.
+
+### The three regimes today
+
+Verified against `dev` at merge commit `6099176` (2026-07-03).
+
+**1. v0.4 native path** — `.create_mock_data_v04()` (`R/create_mock_data.R:98-103`):
+
+```r
+baseline <- generate_mock_data_native(spec, n = n, seed = seed)
+postprocess_seed <- if (is.null(seed)) NULL else seed + 1L
+postprocess_mock_data(baseline, spec, seed = postprocess_seed)
+```
+
+Both stages run inside `.with_mock_seed()` (`R/mock_spec_native.R:8-34`), which
+**saves `.Random.seed`, calls `set.seed()`, and restores the caller's
+`.Random.seed` on exit** — generation is reproducible *and* non-invasive to the
+user's RNG stream. Baseline uses `seed`; post-processing uses `seed + 1L`. The
+`seed + 1L` split is explicitly a pragmatic choice (its own code comment calls it
+that), giving baseline and post-processing "independent" streams by using
+adjacent Mersenne-Twister seeds.
+
+**2. Legacy path** — `create_mock_data()` main body (`R/create_mock_data.R:349-352`):
+
+```r
+if (!is.null(seed)) {
+  if (verbose) message("Setting random seed: ", seed)
+  set.seed(seed)
+}
+```
+
+A bare `set.seed(seed)` with **no save/restore** — this *clobbers the caller's
+global RNG stream*. Generators are then invoked with `seed = NULL`
+(`R/create_mock_data.R:424`, "Global seed already set") and draw sequentially
+from that one stream. The legacy per-variable helpers
+(`sample_with_proportions()`, `make_garbage()`, `apply_garbage()` in
+`R/mockdata_helpers.R`) each *can* self-seed, but on this path receive `NULL`.
+
+**3. simstudy backend** — `generate_mock_data_simstudy()`
+(`R/mock_spec_simstudy.R:223-231`): uses `.with_mock_seed(seed, ...)` — same
+save/restore as the native path, but a single `seed` (no `+ 1L` split).
+
+### What actually differs (and why it matters)
+
+Two independent axes are conflated in the current design:
+
+| Axis | Native (v0.4) | simstudy | Legacy |
+|---|---|---|---|
+| **Isolation** — does generation perturb the caller's RNG? | No (save/restore) | No (save/restore) | **Yes (clobbers)** |
+| **Stream derivation** — how sub-stages get distinct streams | `seed`, `seed+1L` | single `seed` | one shared stream, sequential draws |
+| **RNG kind** | ambient `RNGkind()` | ambient `RNGkind()` | ambient `RNGkind()` |
+
+Three consequences:
+
+1. **Isolation is inconsistent.** `create_mock_data(..., validate = TRUE)` leaves
+   the user's `.Random.seed` untouched; `create_mock_data(..., validate = FALSE)`
+   silently resets it. A user who seeds their own analysis, calls MockData on the
+   legacy path, then draws more random numbers gets *different* downstream results
+   than if they had used the v0.4 path — a surprising, undocumented side effect.
+
+2. **Stream derivation is unprincipled.** `seed` and `seed + 1L` produce
+   well-separated Mersenne-Twister states in practice (R's seeding scrambles the
+   integer through a linear congruential step), so overlap is not a *practical*
+   risk today. But there is no theoretical guarantee, and the scheme does not
+   generalize: #39 and #42 will need a third and fourth stream, and "`seed + 2L`,
+   `seed + 3L`" is not a contract anyone should have to reason about.
+
+3. **RNG kind is unpinned.** All paths call `set.seed(seed)` under whatever
+   `RNGkind()` the session happens to have. A user who has set a non-default
+   generator gets different mock data for the same `seed` — reproducibility is
+   silently conditional on ambient session state the contract never mentions.
+
+### Constraints
+
+- **One break, budgeted.** The post-v0.4.0 plan allocates exactly one
+  seeded-output break for v0.5, covered by one NEWS migration note. This ADR's
+  implementation must land in the same release as #39 (formula evaluator), which
+  independently reorders draws — see Migration.
+- **Dependency ethos.** MockData is MIT and `Imports: stats` only. `parallel` is
+  a base R package (present in every R installation, no new external
+  dependency), so it is available for RNG-stream work at zero dependency cost.
+  A non-base dependency such as `withr` would need explicit justification.
+- **Downstream.** cchsflow/chmsflow (CRAN) consume the recodeflow adapter, not
+  the RNG internals, so this change does not touch shared metadata semantics —
+  but their test suites may pin MockData output, so the break must be announced.
+- **R floor** ≥ 4.2.0; `parallel::nextRNGStream()` and `"L'Ecuyer-CMRG"` have
+  been available far longer, so no floor concern.
+
+## Decision points
+
+Each is a decision the maintainer must make. Recommendations are given but not
+enacted — no code is written until this ADR is accepted.
+
+### D1 — Stream-derivation scheme
+
+How do distinct generation stages (baseline, post-processing, and future formula
+/ correlation stages) get non-overlapping, reproducible streams from one public
+`seed`?
+
+- **(a) Document the status quo.** Keep `seed` / `seed + 1L`; write down that
+  adjacent seeds are treated as independent. Cheapest; no output break for the
+  native path. But it does not generalize to more stages and never becomes
+  *principled*.
+- **(b) L'Ecuyer-CMRG sub-streams via `parallel::nextRNGStream()`.** Seed once
+  from the public `seed` under `RNGkind("L'Ecuyer-CMRG")`, then advance one
+  guaranteed-independent sub-stream per stage. Theoretically sound, base-R only,
+  extends to any number of stages. Cost: changes the RNG kind, so **all seeded
+  output changes** (this is the budgeted break).
+- **(c) Hash-derived per-stage seeds.** Derive each stage's integer seed by
+  hashing `(seed, stage_name)`. Generalizes and reads clearly, but still relies
+  on Mersenne-Twister seed-scrambling for independence (same theoretical gap as
+  (a), just tidier) and adds a hashing helper.
+
+**Recommendation: (b), at stage granularity.** It is the only option that makes
+"independent streams" a guarantee rather than an empirical accident, costs no new
+dependency, and scales to the #39/#40/#42 stages without inventing new arithmetic
+each time. Per-*variable* sub-streams are explicitly **out of scope** (YAGNI
+until parallel generation exists); stages, not variables, are the unit.
+
+### D2 — Isolation: unify the three paths
+
+Should all paths adopt the native path's save/restore behaviour, so no
+`create_mock_data()` call ever perturbs the caller's RNG stream?
+
+- **(a) Unify on save/restore.** Route the legacy path's seeding through the same
+  wrapper as native/simstudy. Removes the surprising side effect; makes isolation
+  a uniform guarantee. Changes legacy-path seeded output (already inside the
+  budgeted break) and touches a stable code path.
+- **(b) Freeze legacy as-is.** Document that the legacy (`validate = FALSE`) path
+  clobbers the RNG stream and leave it; only the v0.4 path gets the new contract.
+  Smaller blast radius, but the contract then has an asterisk and the legacy path
+  keeps a genuine footgun.
+
+**Recommendation: (a).** Isolation should be a property of *MockData*, not of
+which internal path a call happens to take. Extend `.with_mock_seed()` to also
+save/restore `RNGkind` (needed for D1 (b) regardless), set L'Ecuyer-CMRG within
+scope, and have every path — native, simstudy, and legacy — generate inside it.
+This unifies all three regimes under one mechanism and confines the non-default
+RNG kind to the generation scope so the user's session generator is untouched.
+
+### D3 — Guarantee scope (what `seed` promises)
+
+**Recommendation** (a statement to ratify, not options):
+
+> Given identical `seed`, identical resolved `mock_spec`, and identical MockData
+> **package version**, `create_mock_data()` returns identical output — regardless
+> of backend path, ambient `RNGkind()`, or the caller's prior RNG state, and
+> without altering that prior state. Reproducibility is **not** guaranteed across
+> MockData minor versions; each break is announced in NEWS. Nothing about the
+> *statistical* properties of the values (independence across variables,
+> distributional fidelity) is promised — see the design-philosophy scope
+> boundary.
+
+Pinning RNG kind inside the generation scope (D1 (b) / D2 (a)) is what makes the
+"regardless of ambient `RNGkind()`" clause true.
+
+### D4 — Fallback stream-switch announcement (resolves #33 item 11)
+
+When the v0.4 path falls back to the legacy engine for an unsupported feature, it
+switches RNG regimes for the same `seed` (different output), today announced only
+under `verbose = TRUE`. Under the new contract the two regimes differ by RNG kind
+as well, widening the gap.
+
+- **(a) Always-on, once-per-call message** when a fallback switches streams.
+- **(b) Keep it `verbose`-gated.**
+
+**Recommendation: (a).** A silent change in what `seed` produces is exactly the
+class of surprise this ADR exists to remove. One `message()` per call (not per
+variable) is proportionate.
+
+## Consequences
+
+**If accepted as recommended (D1(b), D2(a), D3, D4(a)):**
+
+- One seeded-output break for every path, in v0.5, co-released with #39.
+- `.with_mock_seed()` becomes the single seeding primitive: save/restore
+  `.Random.seed` **and** `RNGkind`, set L'Ecuyer-CMRG, expose a per-stage
+  sub-stream helper. Native, simstudy, and legacy paths all route through it.
+- The `seed + 1L` arithmetic in `.create_mock_data_v04()` is replaced by named
+  stage sub-streams (`"baseline"`, `"postprocess"`, later `"formula"`,
+  `"correlate"`).
+- `create_mock_data()` no longer perturbs the caller's RNG on any path.
+- Reproducibility becomes independent of the user's ambient `RNGkind()`.
+
+**Costs / risks:**
+
+- Every existing test that pins a specific generated value breaks once and must
+  be re-baselined in the same PR. This is the budgeted break, but it is real work
+  and must be done deliberately (regenerate expected values, eyeball a sample for
+  sanity, not blind-accept).
+- Touching the stable legacy path (D2 (a)) carries regression risk; mitigated by
+  the characterization tests merged in #35 and the new pinned-value suite below.
+
+## Test strategy (fulfils #22)
+
+A new `tests/testthat/test-seed-contract.R` pinning the ratified contract:
+
+1. **Determinism** — same `seed` + same spec ⇒ `identical()` output, across the
+   native path, the simstudy path (skip if `simstudy` absent), and the legacy
+   (`validate = FALSE`) path.
+2. **Isolation** — capture `.Random.seed` before and after a seeded
+   `create_mock_data()` call on *every* path; assert unchanged. This is the
+   regression pin for D2.
+3. **RNG-kind independence** — same `seed` under two different ambient
+   `RNGkind()` settings ⇒ `identical()` output (pins D1(b)/D3).
+4. **Stage independence** — baseline and post-processing draws are not trivially
+   correlated (e.g. differ where a naïve shared stream would coincide).
+5. **Pinned values** — a small `expect_equal` against committed reference output
+   for one canonical spec, so the *next* accidental break is caught loudly. These
+   are the values re-baselined when this ADR's implementation lands.
+
+## Migration
+
+- Implementation is written only after this ADR is accepted, as its own plan
+  (`development/plans/YYYY-MM-DD-seed-contract.md`) per the post-v0.4.0 plan's
+  ADR-gate rule.
+- **Co-release with #39.** The formula evaluator reorders draws by dependency and
+  so changes seeded output on its own; batching both into one v0.5 release means
+  one NEWS migration note, not two. #40 (survival pairs) may ride the same release
+  (no independent seed impact). #42 (correlations) must not begin until this lands
+  — it is the fourth RNG consumer and needs the stage-substream mechanism.
+- **NEWS migration note** states plainly: seeded output changes once in v0.5;
+  same-version reproducibility is unaffected; pin your own expected values against
+  the version you use. Precedent: the v0.3→v0.4 divergence already documented in
+  NEWS.
+
+## Resolved / carried to implementation
+
+1. D1 (b), D2 (a), D3 (ratified), D4 (a) — see Decision summary. ✅
+2. Co-release of #38 + #39 in v0.5 — confirmed. ✅
+3. **Carried to the implementation plan:** where the pinned reference values (test
+   strategy item 5) live — inline in the test file vs. a committed fixture under
+   `tests/testthat/_snaps/` or `inst/`. Low-stakes; decide when writing the plan.

--- a/development/plans/2026-07-06-seed-contract.md
+++ b/development/plans/2026-07-06-seed-contract.md
@@ -1,0 +1,466 @@
+# Seed & RNG-Stream Contract Implementation Plan (#38)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make one public `seed` reproduce identical MockData output across every generation path, independent of the caller's ambient `RNGkind()` and without perturbing the caller's RNG state — via L'Ecuyer-CMRG per-stage sub-streams — landing the single budgeted seeded-output break for v0.5.
+
+**Architecture:** One seeding primitive, `.with_mock_seed(seed, expr, stage)`, owns all randomness. It saves/restores both `.Random.seed` and `RNGkind`, seeds one `L'Ecuyer-CMRG` stream from the public seed, advances to the named stage's guaranteed-independent sub-stream via `parallel::nextRNGStream()`, and runs the generation expression under it. The native, simstudy, and legacy paths all route through it; stage indices are frozen so future stages (#39 formula, #42 correlate) add without renumbering.
+
+**Tech Stack:** R (≥ 4.2.0), base `parallel` (new Import — ships with every R install, no external dependency), testthat edition 3, roxygen2, renv.
+
+**Decision source:** [development/adr/v05-seed-contract.md](../adr/v05-seed-contract.md) (ACCEPTED 2026-07-06). This plan implements D1(b), D2(a), D3, D4(a).
+
+## Global Constraints
+
+Inherited from `development/post-v040-development-plan.md` Global Constraints (R floor, `en_US.UTF-8` CI, `roxygenize()` before pkgdown, no committing check artefacts, plain-imperative commits with no AI credit, review before push, fixtures via `system.file()` + skip guards). Plus, specific to this workstream:
+
+- **This is the budgeted break.** Seeded output changes once, here. Every value-pinning test breaks and is re-baselined *deliberately* (regenerate → sanity-check → paste), never blind-accepted. A test asserting a *property* (range, type, count, error message) that breaks is a real regression — stop, do not edit it green.
+- **`parallel` is base R.** Add it to `DESCRIPTION` `Imports` and use `parallel::nextRNGStream()`. Run `renv::snapshot()` after (base packages usually don't alter `renv.lock`; commit it only if it changes).
+- **Stage indices are frozen** at `baseline = 0, postprocess = 1, formula = 2, correlate = 3`. Reserve `formula`/`correlate` now though unused, so #39/#42 don't renumber existing streams and re-break output.
+- **Co-releases with #39** in v0.5 — do not tag until both land. This plan is #38 only.
+- **Downstream:** cchsflow/chmsflow may pin MockData output; the NEWS migration note is mandatory.
+
+## The mechanism (read before Task 1)
+
+R's default Mersenne-Twister has no guaranteed stream-splitting. `L'Ecuyer-CMRG` does: `parallel::nextRNGStream(state)` returns a state advanced 2^127 steps — provably non-overlapping. Pattern:
+
+```r
+set.seed(seed, kind = "L'Ecuyer-CMRG")   # sets kind AND seeds in one call
+stream <- .Random.seed                    # sub-stream 0 (baseline)
+stream <- parallel::nextRNGStream(stream) # sub-stream 1 (postprocess)
+assign(".Random.seed", stream, envir = .GlobalEnv)  # install; draws now use it
+```
+
+Because the kind is pinned inside the scope and `.Random.seed`/`RNGkind` are saved and restored around it, output is independent of ambient `RNGkind()` and the caller's stream is untouched. Lazy evaluation makes wrapping work: `.with_mock_seed(seed, { df[[v]] <- ... })` forces the `{...}` promise in the *caller's* frame, so assignments inside it persist — this is how the native path already operates and how the legacy loop will be wrapped.
+
+## File structure
+
+- `R/mock_spec_native.R` — `.MOCK_STAGES` (new), `.with_mock_seed()` (extend), `generate_mock_data_native()` call site.
+- `R/mock_spec_postprocess.R` — `postprocess_mock_data()` call site → stage `"postprocess"`.
+- `R/mock_spec_simstudy.R` — `generate_mock_data_simstudy()` call site → stage `"baseline"`.
+- `R/create_mock_data.R` — `.create_mock_data_v04()` drop `seed + 1L`; legacy loop wrap; always-on fallback message; roxygen `@details` seed paragraph.
+- `DESCRIPTION` — add `parallel` to `Imports`.
+- `tests/testthat/test-seed-contract.R` — new contract suite.
+- `NEWS.md` — migration note.
+- Re-baselined value-pin tests across `tests/testthat/` (discovered during execution).
+
+---
+
+### Task 1: RNG primitive + native/spec-layer wiring
+
+**Files:**
+- Modify: `R/mock_spec_native.R` (add `.MOCK_STAGES`; rewrite `.with_mock_seed()` at :8-34; `generate_mock_data_native()` call at :349)
+- Modify: `R/mock_spec_postprocess.R:373` (call site)
+- Modify: `R/mock_spec_simstudy.R:231` (call site)
+- Modify: `R/create_mock_data.R` (`.create_mock_data_v04()` :98-103; `@details` seed paragraph :164-166)
+- Modify: `DESCRIPTION` (Imports)
+- Test: `tests/testthat/test-seed-contract.R` (new)
+
+**Interfaces:**
+- Produces: `.with_mock_seed(seed, expr, stage = "baseline")` — save/restore `.Random.seed` + `RNGkind`; L'Ecuyer sub-stream per stage; returns `force(expr)`. `.MOCK_STAGES` named int vector. Consumed by Task 2 (legacy path).
+
+- [ ] **Step 1: Write the failing contract tests (primitive + native level)**
+
+```r
+# tests/testthat/test-seed-contract.R
+# Contract pinned by ADR development/adr/v05-seed-contract.md (#38).
+
+test_that("distinct stages yield distinct, reproducible streams from one seed", {
+  draw <- function(stage) MockData:::.with_mock_seed(1L, runif(5), stage = stage)
+  expect_false(identical(draw("baseline"), draw("postprocess")))
+  expect_identical(draw("baseline"), draw("baseline"))
+})
+
+test_that("seeded generation leaves the caller's RNG state and kind untouched", {
+  set.seed(999)
+  before_state <- .Random.seed
+  before_kind <- RNGkind()
+  spec <- mock_continuous("age", range = c(18, 80))
+  generate_mock_data_native(spec, n = 50, seed = 42)
+  expect_identical(.Random.seed, before_state)
+  expect_identical(RNGkind(), before_kind)
+})
+
+test_that("same seed and spec give identical native output", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  expect_identical(
+    generate_mock_data_native(spec, n = 100, seed = 7),
+    generate_mock_data_native(spec, n = 100, seed = 7)
+  )
+})
+
+test_that("native output is independent of the caller's ambient RNGkind", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  old <- RNGkind()
+  on.exit(RNGkind(kind = old[1], normal.kind = old[2], sample.kind = old[3]), add = TRUE)
+  RNGkind("Mersenne-Twister")
+  a <- generate_mock_data_native(spec, n = 100, seed = 7)
+  RNGkind("Marsaglia-Multicarry")
+  b <- generate_mock_data_native(spec, n = 100, seed = 7)
+  expect_identical(a, b)
+})
+```
+
+- [ ] **Step 2: Run — verify failure**
+
+Run: `Rscript -e 'devtools::load_all(quiet = TRUE); testthat::test_file("tests/testthat/test-seed-contract.R")'`
+Expected: FAIL — `.with_mock_seed()` has no `stage` argument yet (unused-argument error), and RNGkind-independence fails because current code uses ambient MT.
+
+- [ ] **Step 3: Add `.MOCK_STAGES` and rewrite `.with_mock_seed()`**
+
+In `R/mock_spec_native.R`, replace the existing `.with_mock_seed` (:8-34) with:
+
+```r
+# Named generation stages -> fixed L'Ecuyer-CMRG sub-stream indices. Indices
+# are FROZEN: adding a future stage must not renumber baseline/postprocess, or
+# seeded output for existing features would shift. formula (#39) and correlate
+# (#42) are reserved now though unused in this release.
+.MOCK_STAGES <- c(
+  baseline    = 0L,
+  postprocess = 1L,
+  formula     = 2L,
+  correlate   = 3L
+)
+
+#' @noRd
+.with_mock_seed <- function(seed, expr, stage = "baseline") {
+  if (is.null(seed)) {
+    return(force(expr))
+  }
+
+  if (!is.numeric(seed) || length(seed) != 1 || is.na(seed) || seed != floor(seed)) {
+    stop("seed must be a single whole number.", call. = FALSE)
+  }
+  if (!stage %in% names(.MOCK_STAGES)) {
+    stop("Unknown generation stage: '", stage, "'.", call. = FALSE)
+  }
+
+  # Save the caller's RNG state AND kind so generation never perturbs them.
+  old_kind <- RNGkind()
+  had_seed <- exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+  if (had_seed) {
+    old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+  }
+  on.exit({
+    RNGkind(kind = old_kind[1], normal.kind = old_kind[2], sample.kind = old_kind[3])
+    if (had_seed) {
+      assign(".Random.seed", old_seed, envir = .GlobalEnv)
+    } else if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+      rm(".Random.seed", envir = .GlobalEnv)
+    }
+  }, add = TRUE)
+
+  # One L'Ecuyer-CMRG stream from the public seed, advanced to this stage's
+  # provably-independent sub-stream. Pinning the kind makes output independent
+  # of the caller's ambient RNGkind().
+  set.seed(seed, kind = "L'Ecuyer-CMRG")
+  stream <- .Random.seed
+  for (i in seq_len(.MOCK_STAGES[[stage]])) {
+    stream <- parallel::nextRNGStream(stream)
+  }
+  assign(".Random.seed", stream, envir = .GlobalEnv)
+
+  force(expr)
+}
+```
+
+- [ ] **Step 4: Point the three spec-layer call sites at their stages**
+
+`R/mock_spec_native.R:349` — `generate_mock_data_native()`: change `.with_mock_seed(seed, {` to `.with_mock_seed(seed, stage = "baseline", {` (or add `stage = "baseline"` after the `expr` — since `expr` is positional and `{...}` is large, pass `stage` as the named 3rd arg *after* the block: keep `.with_mock_seed(seed, { ... })` and append `, stage = "baseline")` — baseline is the default, so this call may be left unchanged; make it explicit for clarity).
+
+`R/mock_spec_postprocess.R:373` — `postprocess_mock_data()`: the `.with_mock_seed(seed, { ... })` must pass `stage = "postprocess"`. Add the named argument.
+
+`R/mock_spec_simstudy.R:231` — `generate_mock_data_simstudy()`: it is an alternative *baseline* backend; pass `stage = "baseline"` (explicit).
+
+(Because `stage` is a named argument with default `"baseline"`, add it after the closing brace of the block, e.g. `.with_mock_seed(seed, stage = "postprocess", { ... })` — verify the call parses.)
+
+- [ ] **Step 5: Drop the `seed + 1L` split in the orchestrator**
+
+`R/create_mock_data.R:98-103` — replace:
+
+```r
+  baseline <- generate_mock_data_native(spec, n = n, seed = seed)
+  # The wrapper uses a second deterministic stream for post-processing so
+  # baseline generation and missing/garbage assignment can be reproduced
+  # independently from the single public seed.
+  postprocess_seed <- if (is.null(seed)) NULL else seed + 1L
+  postprocess_mock_data(baseline, spec, seed = postprocess_seed)
+```
+
+with:
+
+```r
+  baseline <- generate_mock_data_native(spec, n = n, seed = seed)
+  # Baseline and post-processing use distinct L'Ecuyer-CMRG sub-streams derived
+  # from the single public seed (see .with_mock_seed / ADR v05-seed-contract),
+  # so both stages pass the same seed and select their own stage internally.
+  postprocess_mock_data(baseline, spec, seed = seed)
+```
+
+Then fix the now-stale `@details` seed paragraph at `R/create_mock_data.R:164-166` ("seed + 1 is used for post-processing…") to describe the sub-stream contract, e.g.: "In the v0.4 path, baseline generation and post-processing draw from distinct, independent sub-streams derived from a single `seed`; output is reproducible for a given seed and package version but changed in v0.5 (see NEWS)."
+
+- [ ] **Step 6: Add `parallel` to Imports**
+
+`DESCRIPTION` — under `Imports:`, add `parallel` beside `stats`:
+
+```
+Imports:
+    parallel,
+    stats
+```
+
+- [ ] **Step 7: Document, then run the contract tests**
+
+Run: `Rscript -e 'devtools::document()'` (no roxygen surface change expected beyond the edited `@details`; confirm clean).
+Run: `Rscript -e 'devtools::load_all(quiet = TRUE); testthat::test_file("tests/testthat/test-seed-contract.R")'`
+Expected: all four PASS.
+
+- [ ] **Step 8: Re-baseline the value-pin tests broken by the MT→L'Ecuyer switch**
+
+Run: `Rscript -e 'devtools::test()' 2>&1 | tee /private/tmp/claude-502/-Users-dmanuel-github-mock-data/20beff35-3d8d-499a-b425-4bfa03cd3bb1/scratchpad/seed-break-t1.log`
+
+Triage every failure:
+- **Exact-value assertion** (`expect_equal`/`expect_identical` against a hard-coded number or vector produced under a seed): expected re-baseline. Read the new actual value from the failure output and VERIFY before pasting: value(s) within the variable's declared range; correct type/class/length; for a distribution, mean/spread in the right ballpark (draw a quick `summary()` if unsure). Then replace the literal. Never blind-copy the failure's "actual".
+- **Property assertion** (range, count, NA-proportion within tolerance, type, error message, `expect_error`): if this broke, it is a REAL regression — STOP and report BLOCKED with the test and output. Do not edit it to pass.
+
+Re-run `devtools::test()` until green (0 FAIL; pre-existing 10 skips OK; WARN not above the pre-existing baseline of 35).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add R/mock_spec_native.R R/mock_spec_postprocess.R R/mock_spec_simstudy.R \
+        R/create_mock_data.R DESCRIPTION tests/testthat/test-seed-contract.R \
+        man/ NEWS.md
+# (NEWS.md only if you added the note here; otherwise defer to Task 3)
+git commit -m "Adopt L'Ecuyer-CMRG per-stage seed sub-streams (#38)
+
+Replace the seed/seed+1L split with named, provably-independent
+sub-streams (baseline, postprocess) derived from one public seed via
+parallel::nextRNGStream(). .with_mock_seed() now pins RNGkind within
+scope and restores it, so output no longer depends on the caller's
+ambient RNGkind(). Native, postprocess, and simstudy paths route
+through it. Re-baselines value-pinning tests for the RNG change."
+```
+
+---
+
+### Task 2: Unify legacy-path isolation + always-on fallback message
+
+**Files:**
+- Modify: `R/create_mock_data.R` (legacy seed block :347-352; generation loop wrap; fallback message after :296-298)
+- Test: `tests/testthat/test-seed-contract.R` (append)
+
+**Interfaces:**
+- Consumes: `.with_mock_seed()` and `.MOCK_STAGES` from Task 1.
+- Produces: legacy path no longer clobbers the caller's RNG; a once-per-call `message()` when the v0.4 path silently falls back to legacy.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/testthat/test-seed-contract.R`:
+
+```r
+test_that("legacy path (validate = FALSE) leaves the caller's RNG untouched", {
+  vars <- system.file("extdata", "minimal-example", "variables.csv", package = "MockData")
+  dets <- system.file("extdata", "minimal-example", "variable_details.csv", package = "MockData")
+  if (!nzchar(vars) || !nzchar(dets)) skip("minimal-example fixtures not installed")
+  variables <- read.csv(vars, stringsAsFactors = FALSE, check.names = FALSE)
+  variable_details <- read.csv(dets, stringsAsFactors = FALSE, check.names = FALSE)
+
+  set.seed(123)
+  before <- .Random.seed
+  suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details,
+                     n = 20, seed = 42, validate = FALSE)
+  ))
+  expect_identical(.Random.seed, before)
+})
+
+test_that("legacy path is reproducible for a given seed", {
+  vars <- system.file("extdata", "minimal-example", "variables.csv", package = "MockData")
+  dets <- system.file("extdata", "minimal-example", "variable_details.csv", package = "MockData")
+  if (!nzchar(vars) || !nzchar(dets)) skip("minimal-example fixtures not installed")
+  variables <- read.csv(vars, stringsAsFactors = FALSE, check.names = FALSE)
+  variable_details <- read.csv(dets, stringsAsFactors = FALSE, check.names = FALSE)
+  a <- suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details, n = 20, seed = 42, validate = FALSE)))
+  b <- suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details, n = 20, seed = 42, validate = FALSE)))
+  expect_identical(a, b)
+})
+```
+
+- [ ] **Step 2: Run — verify the isolation test fails**
+
+Run: `Rscript -e 'devtools::load_all(quiet = TRUE); testthat::test_file("tests/testthat/test-seed-contract.R")'`
+Expected: "legacy path … leaves the caller's RNG untouched" FAILS (current bare `set.seed()` clobbers `.Random.seed`). The reproducibility test may pass already.
+
+- [ ] **Step 3: Replace the bare `set.seed` and wrap the generation loop**
+
+`R/create_mock_data.R` — remove the SET GLOBAL SEED block (:347-352):
+
+```r
+  # ========== SET GLOBAL SEED ==========
+
+  if (!is.null(seed)) {
+    if (verbose) message("Setting random seed: ", seed)
+    set.seed(seed)
+  }
+```
+
+Wrap the variable-generation loop (the `for (i in seq_len(nrow(enabled_vars)))` block, currently ~:374 onward through its closing brace) in `.with_mock_seed(seed, stage = "baseline", { ... })`. Because the promise is forced in this frame, in-loop assignments (`df_mock[[var_name]] <- …`, `skipped_vars <- …`) persist. Concretely, change:
+
+```r
+  for (i in seq_len(nrow(enabled_vars))) {
+    ...
+  }
+```
+
+to:
+
+```r
+  .with_mock_seed(seed, stage = "baseline", {
+    for (i in seq_len(nrow(enabled_vars))) {
+      ...
+    }
+  })
+```
+
+Do not alter the loop body or the post-loop assembly. If `verbose`, keep a seed message inside the wrapper: `if (!is.null(seed) && verbose) message("Setting random seed: ", seed)` as the first line inside the block.
+
+- [ ] **Step 4: Add the always-on fallback message (D4)**
+
+`R/create_mock_data.R:286-298` — the `else` branch attempts v0.4 and falls through when `v04_result` is NULL. Add an always-on message on that silent-fallback edge only:
+
+```r
+  } else {
+    v04_result <- .create_mock_data_v04(
+      databaseStart = databaseStart,
+      variables = variables,
+      variable_details = variable_details,
+      n = n,
+      seed = seed,
+      verbose = verbose
+    )
+
+    if (!is.null(v04_result)) {
+      return(v04_result)
+    }
+
+    message(
+      "Falling back to the legacy generator for an unsupported v0.4 feature; ",
+      "for a given seed this produces different values than the v0.4 pipeline."
+    )
+  }
+```
+
+(Do not add it to the `validate = FALSE` or `variable_details = NULL` branches — those are explicit user choices already messaged under `verbose`.)
+
+- [ ] **Step 5: Run the contract tests, then re-baseline legacy value-pins**
+
+Run the seed-contract file: expected all PASS (isolation now holds).
+Run: `Rscript -e 'devtools::test()' 2>&1 | tee /private/tmp/claude-502/-Users-dmanuel-github-mock-data/20beff35-3d8d-499a-b425-4bfa03cd3bb1/scratchpad/seed-break-t2.log`
+Apply the same triage as Task 1 Step 8 to any newly-broken value-pin tests on the legacy path (they switched MT→L'Ecuyer). Property regressions → STOP. A new fallback `message()` may surface in tests that call the fallback edge without `suppressMessages()` — wrap those calls, do not silence the message globally.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add R/create_mock_data.R tests/testthat/
+git commit -m "Unify legacy path on the seed contract and announce fallbacks (#38)
+
+Route the legacy generation loop through .with_mock_seed() so it no
+longer clobbers the caller's RNG stream, matching the native path.
+Emit an always-on message when the v0.4 path silently falls back to
+the legacy generator for an unsupported feature (resolves #33 item 11).
+Re-baselines affected legacy value-pin tests."
+```
+
+---
+
+### Task 3: Contract test suite completion, docs, NEWS
+
+**Files:**
+- Modify: `tests/testthat/test-seed-contract.R` (cross-path + pinned reference values)
+- Modify: `R/mock_spec_native.R`, `R/mock_spec_postprocess.R`, `R/mock_spec_simstudy.R` (`@param seed` consistency)
+- Modify: `NEWS.md`
+- Modify: `man/` (regenerated)
+
+**Interfaces:** consumes everything above; no new production code.
+
+- [ ] **Step 1: Add cross-path determinism and pinned-reference tests**
+
+Append to `tests/testthat/test-seed-contract.R`:
+
+```r
+test_that("full orchestrated pipeline is reproducible for a given seed", {
+  vars <- system.file("extdata", "minimal-example", "variables.csv", package = "MockData")
+  dets <- system.file("extdata", "minimal-example", "variable_details.csv", package = "MockData")
+  if (!nzchar(vars) || !nzchar(dets)) skip("minimal-example fixtures not installed")
+  variables <- read.csv(vars, stringsAsFactors = FALSE, check.names = FALSE)
+  variable_details <- read.csv(dets, stringsAsFactors = FALSE, check.names = FALSE)
+  a <- suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details, n = 50, seed = 1)))
+  b <- suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details, n = 50, seed = 1)))
+  expect_identical(a, b)
+})
+
+test_that("pinned reference values catch the next accidental RNG change", {
+  spec <- mock_continuous("x", range = c(0, 1))
+  got <- generate_mock_data_native(spec, n = 3, seed = 20260706)$x
+  # Reference values captured under the v0.5 L'Ecuyer-CMRG contract. If this
+  # breaks, seeded output changed — treat as a deliberate, NEWS-documented break,
+  # not a silent one.
+  expect_equal(got, c(<FILL FROM FIRST GREEN RUN>), tolerance = 1e-8)
+})
+```
+
+For the pinned test: run it once, read the three actual values, sanity-check they lie in `[0, 1]`, and paste them into `<FILL FROM FIRST GREEN RUN>`. This is the golden baseline; capturing it is the point.
+
+- [ ] **Step 2: Harmonize `@param seed` docs**
+
+In `generate_mock_data_native()`, `postprocess_mock_data()`, and `generate_mock_data_simstudy()`, make each `@param seed` state the shared contract, e.g.: "Optional whole-number seed. Generation uses an isolated L'Ecuyer-CMRG sub-stream and restores the caller's RNG state and kind on exit, so output is reproducible for a given seed and package version without perturbing the caller's RNG." Run `Rscript -e 'devtools::document()'`.
+
+- [ ] **Step 3: NEWS migration note**
+
+Under `# MockData (development version)` in `NEWS.md`:
+
+```markdown
+## Reproducibility (breaking change)
+
+- Seeded output changed once in this release. MockData now derives all
+  randomness from independent L'Ecuyer-CMRG sub-streams (one per generation
+  stage) seeded from the single public `seed`, replacing the previous
+  Mersenne-Twister `seed` / `seed + 1` scheme. For a given seed **and package
+  version** output is reproducible and independent of the session's ambient
+  `RNGkind()`; it is not comparable across the v0.4 → v0.5 boundary. Pin your
+  own expected values against the version you use. Generation no longer alters
+  the caller's RNG state on any path (previously the legacy `validate = FALSE`
+  path reset it).
+```
+
+- [ ] **Step 4: Full verification**
+
+Run: `Rscript -e 'devtools::test()'` — 0 FAIL, ≤10 skips, ≤35 WARN.
+Run: `Rscript -e 'devtools::check()'` — no new ERRORs/WARNINGs/NOTEs attributable to this work (a `parallel` Import NOTE, if any, is expected and acceptable).
+Run: `Rscript -e 'renv::snapshot()'` — commit `renv.lock` only if it changed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/testthat/test-seed-contract.R NEWS.md man/ R/ renv.lock
+git commit -m "Complete seed-contract tests and docs (#38)
+
+Add cross-path determinism and pinned-reference tests, harmonize the
+seed @param docs across the three generators, and document the v0.5
+reproducibility break in NEWS. Fulfils #22."
+```
+
+---
+
+## Self-review (performed at plan date)
+
+- **ADR coverage:** D1(b) sub-streams — Task 1 Step 3; D2(a) unify isolation — Task 1 (native/simstudy/postprocess already save/restore; Task 2 legacy); D3 guarantee — pinned + RNGkind-independence tests; D4(a) always-on fallback — Task 2 Step 4. Test strategy items 1–5 map to Task 1 Steps 1, Task 2 Step 1, Task 3 Step 1.
+- **Placeholder scan:** the only intentional fill-in is the pinned reference vector (Task 3 Step 1), which cannot exist until the mechanism runs; the step specifies exactly how to capture and sanity-check it. Re-baselining (Task 1 Step 8, Task 2 Step 5) is genuine golden-value regeneration with explicit triage criteria, not hand-waving.
+- **Type consistency:** `.with_mock_seed(seed, expr, stage = "baseline")` signature and `.MOCK_STAGES` names (`baseline`/`postprocess`/`formula`/`correlate`) are used identically at every call site; `stage` passed as a named argument everywhere because `expr` is a large positional block.
+- **Sequencing risk:** Task 1 changes RNG output → its own tests re-baseline within the task, so each task ends green. Legacy wrap (Task 2) is the highest-risk edit; its isolation test is written red-first to prove the fix.
+- **Open item carried from ADR:** pinned-reference storage location — chosen here as inline in the test file (simplest; a fixture under `_snaps/` is unnecessary for three scalars).

--- a/tests/testthat/test-create-mock-data-v04.R
+++ b/tests/testthat/test-create-mock-data-v04.R
@@ -77,6 +77,71 @@ test_that("create_mock_data keeps legacy fallback for unsupported v0.4 backend f
   expect_null(attr(result, "mockdata_diagnostics"))
 })
 
+test_that("create_mock_data announces the always-on legacy fallback message", {
+  # Same unsupported-distribution scenario as the "lognormal" fallback test
+  # above, but asserting the always-on (non-verbose-gated) fallback message
+  # that previously had zero test coverage.
+  variables <- data.frame(
+    variable = "time_to_visit",
+    variableType = "Continuous",
+    rType = "double",
+    role = "enabled",
+    distribution = "lognormal",
+    stringsAsFactors = FALSE
+  )
+  variable_details <- data.frame(
+    variable = "time_to_visit",
+    recStart = "[0, 10]",
+    recEnd = "copy",
+    proportion = 1,
+    stringsAsFactors = FALSE
+  )
+
+  expect_message(
+    create_mock_data(
+      databaseStart = "study",
+      variables = variables,
+      variable_details = variable_details,
+      n = 50,
+      seed = 202
+    ),
+    "Falling back to the legacy generator"
+  )
+})
+
+test_that("the always-on legacy fallback message does not fire for validate = FALSE", {
+  # validate = FALSE never reaches the v0.4 pipeline / fallback branch at
+  # all, so it must not emit the "Falling back to the legacy generator"
+  # message (it has its own explicit, verbose-gated announcement instead).
+  variables <- data.frame(
+    variable = "smoking",
+    variableType = "Categorical",
+    rType = "character",
+    role = "enabled",
+    stringsAsFactors = FALSE
+  )
+  variable_details <- data.frame(
+    variable = "smoking",
+    recStart = c("1", "2"),
+    recEnd = c("copy", "copy"),
+    proportion = c(0.6, 0.4),
+    stringsAsFactors = FALSE
+  )
+
+  expect_no_message(
+    create_mock_data(
+      databaseStart = "study",
+      variables = variables,
+      variable_details = variable_details,
+      n = 20,
+      seed = 404,
+      validate = FALSE,
+      verbose = FALSE
+    ),
+    message = "Falling back to the legacy generator"
+  )
+})
+
 test_that("create_mock_data keeps legacy detail-level databaseStart filtering", {
   variables <- data.frame(
     variable = "smoking",

--- a/tests/testthat/test-seed-contract.R
+++ b/tests/testthat/test-seed-contract.R
@@ -89,8 +89,10 @@ test_that("native output is independent of ambient normal.kind and sample.kind",
   on.exit(RNGkind(kind = old[1], normal.kind = old[2], sample.kind = old[3]), add = TRUE)
   RNGkind(normal.kind = "Inversion", sample.kind = "Rejection")
   a <- generate_mock_data_native(spec, n = 200, seed = 7)
-  suppressWarnings(RNGkind(normal.kind = "Box-Muller", sample.kind = "Rounding"))
-  b <- generate_mock_data_native(spec, n = 200, seed = 7)
+  suppressWarnings({
+    RNGkind(normal.kind = "Box-Muller", sample.kind = "Rounding")
+    b <- generate_mock_data_native(spec, n = 200, seed = 7)
+  })
   expect_identical(a, b)
 })
 

--- a/tests/testthat/test-seed-contract.R
+++ b/tests/testthat/test-seed-contract.R
@@ -37,3 +37,32 @@ test_that("native output is independent of the caller's ambient RNGkind", {
   })
   expect_identical(a, b)
 })
+
+test_that("legacy path (validate = FALSE) leaves the caller's RNG untouched", {
+  vars <- system.file("extdata", "minimal-example", "variables.csv", package = "MockData")
+  dets <- system.file("extdata", "minimal-example", "variable_details.csv", package = "MockData")
+  if (!nzchar(vars) || !nzchar(dets)) skip("minimal-example fixtures not installed")
+  variables <- read.csv(vars, stringsAsFactors = FALSE, check.names = FALSE)
+  variable_details <- read.csv(dets, stringsAsFactors = FALSE, check.names = FALSE)
+
+  set.seed(123)
+  before <- .Random.seed
+  suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details,
+                     n = 20, seed = 42, validate = FALSE)
+  ))
+  expect_identical(.Random.seed, before)
+})
+
+test_that("legacy path is reproducible for a given seed", {
+  vars <- system.file("extdata", "minimal-example", "variables.csv", package = "MockData")
+  dets <- system.file("extdata", "minimal-example", "variable_details.csv", package = "MockData")
+  if (!nzchar(vars) || !nzchar(dets)) skip("minimal-example fixtures not installed")
+  variables <- read.csv(vars, stringsAsFactors = FALSE, check.names = FALSE)
+  variable_details <- read.csv(dets, stringsAsFactors = FALSE, check.names = FALSE)
+  a <- suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details, n = 20, seed = 42, validate = FALSE)))
+  b <- suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details, n = 20, seed = 42, validate = FALSE)))
+  expect_identical(a, b)
+})

--- a/tests/testthat/test-seed-contract.R
+++ b/tests/testthat/test-seed-contract.R
@@ -80,6 +80,20 @@ test_that("full orchestrated pipeline is reproducible for a given seed", {
   expect_identical(a, b)
 })
 
+test_that("native output is independent of ambient normal.kind and sample.kind", {
+  spec <- mock_spec(
+    mock_spec_continuous("y", range = c(0, 100), distribution = "normal", mean = 50, sd = 10),
+    mock_spec_categorical("g", levels = c("a", "b", "c"))
+  )
+  old <- RNGkind()
+  on.exit(RNGkind(kind = old[1], normal.kind = old[2], sample.kind = old[3]), add = TRUE)
+  RNGkind(normal.kind = "Inversion", sample.kind = "Rejection")
+  a <- generate_mock_data_native(spec, n = 200, seed = 7)
+  suppressWarnings(RNGkind(normal.kind = "Box-Muller", sample.kind = "Rounding"))
+  b <- generate_mock_data_native(spec, n = 200, seed = 7)
+  expect_identical(a, b)
+})
+
 test_that("pinned reference values catch the next accidental RNG change", {
   spec <- mock_continuous("x", range = c(0, 1))
   got <- generate_mock_data_native(spec, n = 3, seed = 20260706)$x

--- a/tests/testthat/test-seed-contract.R
+++ b/tests/testthat/test-seed-contract.R
@@ -31,7 +31,9 @@ test_that("native output is independent of the caller's ambient RNGkind", {
   on.exit(RNGkind(kind = old[1], normal.kind = old[2], sample.kind = old[3]), add = TRUE)
   RNGkind("Mersenne-Twister")
   a <- generate_mock_data_native(spec, n = 100, seed = 7)
-  RNGkind("Marsaglia-Multicarry")
-  b <- generate_mock_data_native(spec, n = 100, seed = 7)
+  suppressWarnings({
+    RNGkind("Marsaglia-Multicarry")
+    b <- generate_mock_data_native(spec, n = 100, seed = 7)
+  })
   expect_identical(a, b)
 })

--- a/tests/testthat/test-seed-contract.R
+++ b/tests/testthat/test-seed-contract.R
@@ -96,6 +96,31 @@ test_that("native output is independent of ambient normal.kind and sample.kind",
   expect_identical(a, b)
 })
 
+test_that("stage indices are frozen (renumbering would shift seeded output)", {
+  expect_identical(
+    MockData:::.MOCK_STAGES,
+    c(baseline = 0L, postprocess = 1L, formula = 2L, correlate = 3L)
+  )
+})
+
+test_that("postprocess stage output is pinned (catches a stage-index shift)", {
+  spec <- mock_continuous(
+    "age", range = c(18, 80),
+    missing_codes = -99, missing_proportions = 0.3
+  )
+  baseline <- generate_mock_data_native(spec, n = 5, seed = 20260706)
+  pp <- postprocess_mock_data(baseline, spec, seed = 20260706)
+  # Reference captured under the v0.5 L'Ecuyer-CMRG contract, postprocess
+  # sub-stream (index 1). If this breaks, the postprocess stream shifted
+  # (e.g. a stage was inserted before it) or generation changed - treat as a
+  # deliberate, NEWS-documented break, not a silent one.
+  expect_equal(
+    pp$age,
+    c(-99, 22.2337325980459, -99, 50.837302129287, 46.4571529769078),
+    tolerance = 1e-8
+  )
+})
+
 test_that("pinned reference values catch the next accidental RNG change", {
   spec <- mock_continuous("x", range = c(0, 1))
   got <- generate_mock_data_native(spec, n = 3, seed = 20260706)$x

--- a/tests/testthat/test-seed-contract.R
+++ b/tests/testthat/test-seed-contract.R
@@ -66,3 +66,29 @@ test_that("legacy path is reproducible for a given seed", {
     create_mock_data("minimal-example", variables, variable_details, n = 20, seed = 42, validate = FALSE)))
   expect_identical(a, b)
 })
+
+test_that("full orchestrated pipeline is reproducible for a given seed", {
+  vars <- system.file("extdata", "minimal-example", "variables.csv", package = "MockData")
+  dets <- system.file("extdata", "minimal-example", "variable_details.csv", package = "MockData")
+  if (!nzchar(vars) || !nzchar(dets)) skip("minimal-example fixtures not installed")
+  variables <- read.csv(vars, stringsAsFactors = FALSE, check.names = FALSE)
+  variable_details <- read.csv(dets, stringsAsFactors = FALSE, check.names = FALSE)
+  a <- suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details, n = 50, seed = 1)))
+  b <- suppressWarnings(suppressMessages(
+    create_mock_data("minimal-example", variables, variable_details, n = 50, seed = 1)))
+  expect_identical(a, b)
+})
+
+test_that("pinned reference values catch the next accidental RNG change", {
+  spec <- mock_continuous("x", range = c(0, 1))
+  got <- generate_mock_data_native(spec, n = 3, seed = 20260706)$x
+  # Reference values captured under the v0.5 L'Ecuyer-CMRG contract. If this
+  # breaks, seeded output changed — treat as a deliberate, NEWS-documented break,
+  # not a silent one.
+  expect_equal(
+    got,
+    c(0.626896562612263, 0.068286009645902, 0.426707671898230),
+    tolerance = 1e-8
+  )
+})

--- a/tests/testthat/test-seed-contract.R
+++ b/tests/testthat/test-seed-contract.R
@@ -1,0 +1,37 @@
+# tests/testthat/test-seed-contract.R
+# Contract pinned by ADR development/adr/v05-seed-contract.md (#38).
+
+test_that("distinct stages yield distinct, reproducible streams from one seed", {
+  draw <- function(stage) MockData:::.with_mock_seed(1L, runif(5), stage = stage)
+  expect_false(identical(draw("baseline"), draw("postprocess")))
+  expect_identical(draw("baseline"), draw("baseline"))
+})
+
+test_that("seeded generation leaves the caller's RNG state and kind untouched", {
+  set.seed(999)
+  before_state <- .Random.seed
+  before_kind <- RNGkind()
+  spec <- mock_continuous("age", range = c(18, 80))
+  generate_mock_data_native(spec, n = 50, seed = 42)
+  expect_identical(.Random.seed, before_state)
+  expect_identical(RNGkind(), before_kind)
+})
+
+test_that("same seed and spec give identical native output", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  expect_identical(
+    generate_mock_data_native(spec, n = 100, seed = 7),
+    generate_mock_data_native(spec, n = 100, seed = 7)
+  )
+})
+
+test_that("native output is independent of the caller's ambient RNGkind", {
+  spec <- mock_continuous("age", range = c(18, 80))
+  old <- RNGkind()
+  on.exit(RNGkind(kind = old[1], normal.kind = old[2], sample.kind = old[3]), add = TRUE)
+  RNGkind("Mersenne-Twister")
+  a <- generate_mock_data_native(spec, n = 100, seed = 7)
+  RNGkind("Marsaglia-Multicarry")
+  b <- generate_mock_data_native(spec, n = 100, seed = 7)
+  expect_identical(a, b)
+})

--- a/tests/testthat/test-simstudy-backend.R
+++ b/tests/testthat/test-simstudy-backend.R
@@ -202,6 +202,26 @@ test_that("generate_mock_data_simstudy is reproducible", {
   expect_identical(first, second)
 })
 
+test_that("generate_mock_data_simstudy leaves the caller's RNG state and kind untouched", {
+  skip_if_not_installed("simstudy")
+
+  set.seed(999)
+  before_state <- .Random.seed
+  before_kind <- RNGkind()
+  spec <- mock_spec(
+    mock_spec_continuous("age", range = c(18, 85), rtype = "integer"),
+    mock_spec_categorical(
+      "smoking",
+      levels = c("never", "former", "current"),
+      proportions = c(0.5, 0.3, 0.2),
+      rtype = "character"
+    )
+  )
+  generate_mock_data_simstudy(spec, n = 50, seed = 42)
+  expect_identical(.Random.seed, before_state)
+  expect_identical(RNGkind(), before_kind)
+})
+
 test_that("generate_mock_data_simstudy handles empty specs and n = 0", {
   skip_if_not_installed("simstudy")
 

--- a/vignettes/migrating-from-v03-v04.qmd
+++ b/vignettes/migrating-from-v03-v04.qmd
@@ -139,12 +139,15 @@ table(legacy_data$smoking)
 
 ## Understand seed differences
 
-In v0.3, the public seed controlled the legacy generators. In v0.4, the wrapper
-uses the public seed for baseline generation and `seed + 1L` for missing-code
-and garbage-value post-processing.
+In v0.3, the public seed controlled the legacy generators directly. In v0.4/v0.5,
+the wrapper passes the same public `seed` to both baseline generation and
+missing-code/garbage-value post-processing; internally, each stage draws from
+its own independent L'Ecuyer-CMRG sub-stream derived from that single seed
+(stage selection happens inside the package, not via `seed + 1L` as in earlier
+v0.4 releases - see `NEWS.md` for the v0.5 reproducibility change).
 
-That makes both stages reproducible, but it means exact values may differ from
-v0.3 even when you pass the same seed.
+That makes both stages reproducible from one seed, but it means exact values
+may differ from v0.3 even when you pass the same seed.
 
 ```{r}
 strict_again <- create_mock_data(
@@ -241,7 +244,7 @@ validate_mock_spec(spec, strict = TRUE)
 
 ```{r}
 baseline <- generate_mock_data_native(spec, n = 50, seed = 456)
-postprocessed <- postprocess_mock_data(baseline, spec, seed = 457)
+postprocessed <- postprocess_mock_data(baseline, spec, seed = 456)
 
 identical(strict_data, postprocessed)
 ```

--- a/vignettes/recodeflow-metadata-v04.qmd
+++ b/vignettes/recodeflow-metadata-v04.qmd
@@ -213,12 +213,15 @@ head(baseline)
 ```
 
 ```{r}
-postprocessed <- postprocess_mock_data(baseline, spec, seed = 124)
+postprocessed <- postprocess_mock_data(baseline, spec, seed = 123)
 head(postprocessed)
 ```
 
-The wrapper uses the same idea: the public seed controls baseline generation,
-and `seed + 1L` controls post-processing.
+The wrapper uses the same idea: baseline generation and post-processing are
+both passed the same public `seed`, and each stage internally draws from its
+own independent L'Ecuyer-CMRG sub-stream derived from that seed (not
+`seed + 1L`, as in earlier v0.4 releases - see `NEWS.md` for the v0.5
+reproducibility change).
 
 ## Database filtering
 


### PR DESCRIPTION
Phase 2, first workstream of the post-v0.4.0 plan. Implements the accepted seed-contract ADR. **Co-releases with #39 (formula evaluator) — do not tag v0.5 on this alone.** This is the single budgeted seeded-output break for v0.5.

## What changes

`.with_mock_seed()` becomes the one seeding primitive across every generation path:
- Saves/restores both `.Random.seed` **and** `RNGkind` (all three components), so generation never perturbs the caller's RNG on any seeded path — previously the legacy `validate = FALSE` path clobbered it via a bare `set.seed()`.
- Seeds one **L'Ecuyer-CMRG** stream from the single public `seed`, then advances to a named stage's provably-independent sub-stream via `parallel::nextRNGStream()` (base R — no new external dependency). Stage indices are **frozen** (`baseline=0, postprocess=1`; `formula`/`correlate` reserved for #39/#42) so future stages don't reshuffle existing output.
- Replaces the ad-hoc `seed`/`seed+1L` split; native, postprocess, simstudy, and the legacy loop all route through it.
- Always-on message when the v0.4 path silently falls back to the legacy engine (resolves #33 item 11).

## The break

Output for a given seed changes once (Mersenne-Twister → L'Ecuyer-CMRG). It is reproducible for a given seed **and package version**, and now independent of the session's ambient `RNGkind()`. Not comparable across the v0.4→v0.5 boundary — see the NEWS migration note. cchsflow/chmsflow pin against a version, so the note is mandatory.

## Guarantees (ADR D1–D4)

- **D1** independent per-stage sub-streams; **D2** unified isolation across all paths; **D3** same seed + spec + version ⇒ identical output, independent of ambient `RNGkind()`; **D4** always-on fallback message.

## Review history

- Three tasks, each TDD with a per-task spec+quality review.
- A whole-branch review (strongest model) caught an Important defect the four per-task reviews missed: `set.seed(kind = "L'Ecuyer-CMRG")` pinned only the *primary* generator, so `rnorm()` and equal-probability `sample()` still leaked ambient `normal.kind`/`sample.kind`, partially breaking the D3 guarantee. Fixed by pinning all three kind components (a no-op under R ≥ 3.6 defaults, so pinned values were not re-baselined) plus a regression test that varies `normal.kind`/`sample.kind`.

## Tests / docs

- New `tests/testthat/test-seed-contract.R`: isolation (state + kind), determinism, ambient-RNGkind independence (primary, normal, and sample kinds), stage independence, pinned reference values. Fulfils #22.
- Suite at branch head: **FAIL 0 | WARN 35 | SKIP 10 | PASS 695**. `R CMD check`: 0 errors, 0 warnings, 3 environmental NOTEs.
- NEWS breaking-change note; harmonized `@param seed` docs across the three generators.

Implements #38. Fulfils #22. Resolves #33 item 11. Follow-up: #47 (route standalone `create_*`/survival generators through the primitive for package-wide isolation).

Includes the accepted ADR (`development/adr/v05-seed-contract.md`) and the implementation plan (`development/plans/2026-07-06-seed-contract.md`).